### PR TITLE
catch and ignore OutOfMemoryError in getRotatedBitmap()

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -530,8 +530,20 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         } else {
             matrix.setRotate(rotate, (float) bitmap.getWidth() / 2, (float) bitmap.getHeight() / 2);
         }
-        bitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
-        exif.resetOrientation();
+                
+        try
+        {
+            bitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+            exif.resetOrientation();
+        }
+        catch (OutOfMemoryError oom)
+        {
+            // You can run out of memory if the image is very large:
+            // http://simonmacdonald.blogspot.ca/2012/07/change-to-camera-code-in-phonegap-190.html
+            // If this happens, simply do not rotate the image and return it unmodified.
+            // If you do not catch the OutOfMemoryError, the Android app crashes.
+        }
+
         return bitmap;
     }
 


### PR DESCRIPTION
getRotatedBitmap() can run out of memory if the image is very large:

http://simonmacdonald.blogspot.ca/2012/07/change-to-camera-code-in-phonegap-190.html

If this happens, simply do not rotate the image and return it unmodified.  If you do not catch the OutOfMemoryError, the Android app crashes.
