### PR TITLE
Removed iOS doc reference to non-existing navigator.fileMgr API

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -282,7 +282,7 @@ Optional parameters to customize the camera settings.
 
 - Set `quality` below 50 to avoid memory errors on some devices.
 
-- When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory.  You may delete the contents of this directory using the `navigator.fileMgr` APIs if storage space is a concern.
+- When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
 
 ### Tizen Quirks
 


### PR DESCRIPTION
Removed iOS doc reference to non-existing navigator.fileMgr API (see http://mail-archives.apache.org/mod_mbox/cordova-commits/201305.mbox/%3C78e44706afb846f59d4489943b1e4b14@git.apache.org%3E)
