### PR TITLE
Prevent NPE on processResultFromGallery when intent comes null

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -521,7 +521,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         // If retrieving photo from library
         else if ((srcType == PHOTOLIBRARY) || (srcType == SAVEDPHOTOALBUM)) {
-            if (resultCode == Activity.RESULT_OK) {
+            if (resultCode == Activity.RESULT_OK && intent != null) {
                 this.processResultFromGallery(destType, intent);
             }
             else if (resultCode == Activity.RESULT_CANCELED) {


### PR DESCRIPTION
There are cases when onActivityResult returns with Activity.RESULT_OK as resultCode but the intent in null. This produce a NullPointerException trying to get the data from the intent in the processResultFromGallery method.
