### PR TITLE
Make dest NATIVE_URI compatible with source CAMERA

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -677,10 +677,12 @@ static NSSet* org_apache_cordova_validArrowDirections;
     }
     
     if (self.pickerController.saveToPhotoAlbum) {
+    	CDVCamera* __weak weakSelf = self;  // play it safe to avoid retain cycles
         ALAssetsLibrary *library = [ALAssetsLibrary new];
+        
         [library writeImageDataToSavedPhotosAlbum:self.data metadata:self.metadata completionBlock:^(NSURL *assetURL, NSError *error) {
             
-            if (self.pickerController.returnType == DestinationTypeNativeUri) {
+            if (weakSelf.pickerController.returnType == DestinationTypeNativeUri) {
                 CDVPluginResult* result;
                 if (error) {
                     result = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsString:[error localizedDescription]];
@@ -688,12 +690,12 @@ static NSSet* org_apache_cordova_validArrowDirections;
                     result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[assetURL absoluteString]];
                 }
                 
-                [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
+                [weakSelf.commandDelegate sendPluginResult:result callbackId:weakSelf.pickerController.callbackId];
                 
-                self.hasPendingOperation = NO;
-                self.pickerController = nil;
-                self.data = nil;
-                self.metadata = nil;
+                weakSelf.hasPendingOperation = NO;
+                weakSelf.pickerController = nil;
+                weakSelf.data = nil;
+                weakSelf.metadata = nil;
             }
         }];
         

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -277,7 +277,7 @@ static NSSet* org_apache_cordova_validArrowDirections;
     NSString* mediaType = [info objectForKey:UIImagePickerControllerMediaType];
     // IMAGE TYPE
     if ([mediaType isEqualToString:(NSString*)kUTTypeImage]) {
-        if (cameraPicker.returnType == DestinationTypeNativeUri) {
+        if (cameraPicker.returnType == DestinationTypeNativeUri && cameraPicker.sourceType != UIImagePickerControllerSourceTypeCamera) {
             NSString* nativeUri = [(NSURL*)[info objectForKey:UIImagePickerControllerReferenceURL] absoluteString];
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nativeUri];
         } else {
@@ -678,7 +678,29 @@ static NSSet* org_apache_cordova_validArrowDirections;
     
     if (self.pickerController.saveToPhotoAlbum) {
         ALAssetsLibrary *library = [ALAssetsLibrary new];
-        [library writeImageDataToSavedPhotosAlbum:self.data metadata:self.metadata completionBlock:nil];
+        [library writeImageDataToSavedPhotosAlbum:self.data metadata:self.metadata completionBlock:^(NSURL *assetURL, NSError *error) {
+            
+            if (self.pickerController.returnType == DestinationTypeNativeUri) {
+                CDVPluginResult* result;
+                if (error) {
+                    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsString:[error localizedDescription]];
+                } else {
+                    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[assetURL absoluteString]];
+                }
+                
+                [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
+                
+                self.hasPendingOperation = NO;
+                self.pickerController = nil;
+                self.data = nil;
+                self.metadata = nil;
+            }
+        }];
+        
+        if (self.pickerController.returnType == DestinationTypeNativeUri) {
+            // JS callback will be handler in the writeImageDataToSavedPhotosAlbum completionBlock
+            return;
+        }
     }
     
     if (self.pickerController.returnType == DestinationTypeFileUri) {
@@ -703,16 +725,15 @@ static NSSet* org_apache_cordova_validArrowDirections;
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[NSURL fileURLWithPath:filePath] absoluteString]];
         }
     }
-    else {
+    else if (self.pickerController.returnType == DestinationTypeDataUrl) {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[self.data base64EncodedString]];
     }
-    if (result) {
-        [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
+    
+    if (!result) {
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid options"];
     }
     
-    if (result) {
-        [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
-    }
+    [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
     
     self.hasPendingOperation = NO;
     self.pickerController = nil;


### PR DESCRIPTION
When using the camera in iOS, UIImagePickerControllerReferenceURL does not exist because the image only exists in memory immediately after taking a photo. This waits for the image to be written to disk before firing the JS callback when Camera.SourceType.CAMERA, Camera.DestinationType.NATIVE_URI, and saveToPhotoAlbum=true are used together in iOS.