### PR TITLE
[iOS] Returns a specific error message when app has no access to Photos

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -394,7 +394,7 @@ static NSSet* org_apache_cordova_validArrowDirections;
     // popoverControllerDidDismissPopover:(id)popoverController is called if popover is cancelled
 
     CDVPluginResult* result;
-    if ([ALAssetsLibrary authorizationStatus] == ALAuthorizationStatusAuthorized) {
+    if (picker.sourceType == UIImagePickerControllerSourceTypeCamera || [ALAssetsLibrary authorizationStatus] == ALAuthorizationStatusAuthorized) {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no image selected"];   // error callback expects string ATM
     } else {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to assets"];   // error callback expects string ATM


### PR DESCRIPTION
If user cancel the UIImagePickerController and the app has no authorization to access to the Photos, an error with the message "has no access to assets" is returned as the plugin result.
