### PR TITLE
Fix the bug in CDVCamera.m of hasPendingOperation property when takePict...

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -75,7 +75,7 @@ static NSSet* org_apache_cordova_validArrowDirections;
     NSString* callbackId = command.callbackId;
     NSArray* arguments = command.arguments;
 
-    self.hasPendingOperation = NO;
+    self.hasPendingOperation = YES;
 
     NSString* sourceTypeString = [arguments objectAtIndex:2];
     UIImagePickerControllerSourceType sourceType = UIImagePickerControllerSourceTypeCamera; // default
@@ -153,7 +153,7 @@ static NSSet* org_apache_cordova_validArrowDirections;
     } else {
         [self.viewController presentViewController:cameraPicker animated:YES completion:nil];
     }
-    self.hasPendingOperation = YES;
+    self.hasPendingOperation = NO;
 }
 
 - (void)repositionPopover:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
When the operation of takePiture begin, we should set hasPendingOperation to YES, when it ends, we should set that property to NO.
