### PR TITLE
StatusBar Hidden Fix

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -386,6 +386,8 @@ static NSSet* org_apache_cordova_validArrowDirections;
     }
     
     [self.commandDelegate sendPluginResult:result callbackId:cameraPicker.callbackId];
+    
+    [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationNone];
 
     self.hasPendingOperation = NO;
     self.pickerController = nil;


### PR DESCRIPTION
If I click cancel on imagePicker and I have status bar hidden it re-appear, so I have to hide it also in this case.
