### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/CameraProxy.js
+++ b/src/firefoxos/CameraProxy.js
@@ -48,4 +48,4 @@ module.exports = {
     cleanup: function(){}
 };
 
-require("cordova/firefoxos/commandProxy").add("Camera", module.exports);
+require("cordova/exec/proxy").add("Camera", module.exports);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
