### PR TITLE
CB-7259: Set default value of correctOrientation to true in camera plugin

### DIFF
--- a/www/Camera.js
+++ b/www/Camera.js
@@ -55,7 +55,7 @@ cameraExport.getPicture = function(successCallback, errorCallback, options) {
     var encodingType = getValue(options.encodingType, Camera.EncodingType.JPEG);
     var mediaType = getValue(options.mediaType, Camera.MediaType.PICTURE);
     var allowEdit = !!options.allowEdit;
-    var correctOrientation = !!options.correctOrientation;
+    var correctOrientation = options.correctOrientation === undefined ? true : !!options.correctOrientation;
     var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     var popoverOptions = getValue(options.popoverOptions, null);
     var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);


### PR DESCRIPTION
Jira Ticket : CB-7259
https://issues.apache.org/jira/browse/CB-7259

Platform: iOS
Plugin: org.apache.cordova.camera
Hardware: iphone 5

Issue:
Strange behavior when selecting photos from library with camera.getPicture and cameraOptions with sourceType of Camera.PictureSourceType.PHOTOLIBRARY. Some photos rotate in unintuitive ways.

Fix:
I found that defaulting correctOrientation to true in my cameraOptions argument fixed this problem.

Screenshots: 
Before:
![photo 1](https://cloud.githubusercontent.com/assets/7144417/3805452/c19d4d34-1c36-11e4-9b94-7548f6cd13af.PNG)

After:
![photo 2](https://cloud.githubusercontent.com/assets/7144417/3805454/c96995ea-1c36-11e4-947c-3c85e70bf74f.PNG)
