### PR TITLE
CB-7423 do cleanup after copyImage manual test

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -241,10 +241,28 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     function copyImage() {
         var onFileSystemReceived = function (fileSystem) {
             var destDirEntry = fileSystem.root;
+            var origName = fileEntry.name;
 
             // Test FileEntry API here.
             fileEntry.copyTo(destDirEntry, 'copied_file.png', logCallback('FileEntry.copyTo', true), logCallback('FileEntry.copyTo', false));
             fileEntry.moveTo(destDirEntry, 'moved_file.png', logCallback('FileEntry.moveTo', true), logCallback('FileEntry.moveTo', false));
+
+            //cleanup
+            //rename moved file back to original name so other tests can reference image
+            resolveLocalFileSystemURI(destDirEntry.nativeURL+'moved_file.png', function(fileEntry) {
+                fileEntry.moveTo(destDirEntry, origName, logCallback('FileEntry.moveTo', true), logCallback('FileEntry.moveTo', false));
+                console.log('Cleanup: successfully renamed file back to original name');
+            }, function () {
+                console.log('Cleanup: failed to rename file back to original name');
+            });
+
+            //remove copied file
+            resolveLocalFileSystemURI(destDirEntry.nativeURL+'copied_file.png', function(fileEntry) {
+                fileEntry.remove(logCallback('FileEntry.remove', true), logCallback('FileEntry.remove', false));
+                console.log('Cleanup: successfully removed copied file');
+            }, function () {
+                console.log('Cleanup: failed to remove copied file');
+            });
         };
 
         window.requestFileSystem(LocalFileSystem.TEMPORARY, 0, onFileSystemReceived, null);


### PR DESCRIPTION
Running the copy, write, or upload manual tests after doing a copy and without retaking or reselecting an image will cause the test to fail. A cleanup is necessary to rename the "moved" file back to its original name for other tests referencing it and remove the copied file to avoid a PATH_EXISTS_ERR on the next run.
