### PR TITLE
CB-7667 iOS8: Handle case where camera is not authorized

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -146,6 +146,7 @@
          <framework src="AssetsLibrary.framework" />
          <framework src="MobileCoreServices.framework" />
          <framework src="CoreGraphics.framework" />
+         <framework src="AVFoundation.framework" />
          
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
              <string></string>


### PR DESCRIPTION
In iOS 7+, when the app does not have access to the camera, show a
prompt notifying the user so they're not puzzled by looking at a black
screen.

In iOS 8+, include a link on the dialog to open the Setting app to allow
the user to change their Camera privacy setting.

Fixes https://issues.apache.org/jira/browse/CB-7667