### PR TITLE
A __bridge_retained cast increments the count and requires a CFRelease, ...

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -632,7 +632,7 @@ static NSSet* org_apache_cordova_validArrowDirections;
     CDVPluginResult* result = nil;
     
     if (self.metadata) {
-        CGImageSourceRef sourceImage = CGImageSourceCreateWithData((__bridge_retained CFDataRef)self.data, NULL);
+        CGImageSourceRef sourceImage = CGImageSourceCreateWithData((__bridge CFDataRef)self.data, NULL);
         CFStringRef sourceType = CGImageSourceGetType(sourceImage);
         
         CGImageDestinationRef destinationImage = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)self.data, sourceType, 1, NULL);


### PR DESCRIPTION
...this should just be __bridge a cast since it isn’t being held onto by this method.
