### PR TITLE
Fix terminology for selecting a video.

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -203,7 +203,7 @@ static NSSet* org_apache_cordova_validArrowDirections;
         UIImagePickerController * cameraPicker = (UIImagePickerController*)navigationController;
         
         if(![cameraPicker.mediaTypes containsObject:(NSString*) kUTTypeImage]){
-            [viewController.navigationItem setTitle:NSLocalizedString(@"Videos title", nil)];
+            [viewController.navigationItem setTitle:@"Videos"];
         }
     }
 }


### PR DESCRIPTION
Selecting a video currently shows 'Videos title' along the top of the picker.

I believe 'Videos' would be more appropriate. 

The reason it was changed was for localization, which unless I am mistaken has been removed.

(Old commit showing it was previously 'Videos' until localization was added. Probably completely irrelevant)
https://github.com/coryjthompson/cordova-ios/commit/8b0f11fd60bf6966bd40d296cd80b96e2cef6806

Thanks.