### PR TITLE
Specific camera permissions added

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -66,6 +66,7 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.CAMERA"/>
         </config-file>
 
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />


### PR DESCRIPTION
Does this have sense? I need it to get WebRTC (getUserMedia) working with XWalk third party engine.

https://github.com/infil00p/cordova-crosswalk-engine