### PR TITLE
Fix build error no org.apache.cordova.file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,6 +30,8 @@
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-camera.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320645</issue>
 
+    <dependency id="org.apache.cordova.file" version=">=1.0.1" />
+
     <js-module src="www/CameraConstants.js" name="Camera">
         <clobbers target="Camera" />
     </js-module>


### PR DESCRIPTION
Although uses the org.apache.cordova.file.FileUtils package in ac4af88f551406fa7b38a1343a3fc423a9ae9233, there is no dependency org.apache.cordova.file plugin.

```
$ cordova --version
4.3.0
$ cordova create cordova1
$ cd cordova1
$ cordova platform add android
$ cordova plugin add https://github.com/apache/cordova-plugin-camera.git
$ cordova build
...
Running command: /home/masakura/Documents/tmp/cordova1/platforms/android/cordova/build 
Buildfile: /home/masakura/??????????????????/tmp/cordova1/platforms/android/build.xml does not exist!
Build failed

/home/masakura/ドキュメント/tmp/cordova1/platforms/android/cordova/node_modules/q/q.js:126
                    throw e;
                          ^
Error code 1 for command: ant with args: debug,-f,/home/masakura/ドキュメント/tmp/cordova1/platforms/android/build.xml,-Dout.dir=ant-build,-Dgen.absolute.dir=ant-gen
ERROR building one of the platforms: Error: /home/masakura/Documents/tmp/cordova1/platforms/android/cordova/build: Command failed with exit code 8
You may not have the required environment or OS to build this project
Error: /home/masakura/Documents/tmp/cordova1/platforms/android/cordova/build: Command failed with exit code 8
    at ChildProcess.whenDone (/home/masakura/.nvm/v0.10.38/lib/node_modules/cordova/node_modules/cordova-lib/src/cordova/superspawn.js:131:23)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:766:16)
    at Process.ChildProcess._handle.onexit (child_process.js:833:5)
```