### PR TITLE
Fix Android images opening in document viewer

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -270,8 +270,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         croppedUri = null;
         if (this.mediaType == PICTURE) {
             intent.setType("image/*");
+            intent.setAction(Intent.ACTION_PICK);
             if (this.allowEdit) {
-                intent.setAction(Intent.ACTION_PICK);
                 intent.putExtra("crop", "true");
                 if (targetWidth > 0) {
                     intent.putExtra("outputX", targetWidth);
@@ -286,9 +286,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 File photo = createCaptureFile(encodingType);
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
-            } else {
-                intent.setAction(Intent.ACTION_GET_CONTENT);
-                intent.addCategory(Intent.CATEGORY_OPENABLE);
             }
         } else if (this.mediaType == VIDEO) {
                 intent.setType("video/*");


### PR DESCRIPTION
When allowEdit is false, android opens the document viewer instead of photo gallery.
 The change uses ACTION_PICK in both cases, fixing the issue.