### PR TITLE
Major refactor

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -237,10 +237,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      */
     public void callTakePicture(int returnType, int encodingType) {
-        if (cordova.hasPermission(permissions[TAKE_PIC_SEC])) {
+        if (cordova.hasPermission(permissions[TAKE_PIC_SEC]) && cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC])) {
             takePicture(returnType, encodingType);
         } else {
-            PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
+            cordova.requestPermissions(this, TAKE_PIC_SEC, permissions);
         }
     }
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -105,7 +105,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private boolean orientationCorrected;   // Has the picture's orientation been corrected
     private boolean allowEdit;              // Should we allow the user to crop the image.
 
-    protected final static String[] permissions = { Manifest.permission.READ_EXTERNAL_STORAGE };
+    protected final static String[] permissions = { Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE };
 
     public CallbackContext callbackContext;
     private int numPics;
@@ -113,6 +113,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private MediaScannerConnection conn;    // Used to update gallery app with newly-written files
     private Uri scanMe;                     // Uri of image to be added to content store
     private Uri croppedUri;
+
+    protected void getReadPermission(int requestCode)
+    {
+        cordova.requestPermission(this, requestCode, permissions[requestCode]);
+    }
 
     /**
      * Executes the request and returns PluginResult.
@@ -172,8 +177,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     // preserve the original exif data and filename in the modified file that is
                     // created
                     if(this.mediaType == PICTURE && (this.destType == FILE_URI || this.destType == NATIVE_URI)
-                            && fileWillBeModified() && !PermissionHelper.hasPermission(this, permissions[0])) {
-                        PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
+                            && fileWillBeModified() && !cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC])) {
+                        getReadPermission(SAVE_TO_ALBUM_SEC);
                     } else {
                         this.getImage(this.srcType, destType, encodingType);
                     }
@@ -232,7 +237,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      */
     public void callTakePicture(int returnType, int encodingType) {
-        if (PermissionHelper.hasPermission(this, permissions[0])) {
+        if (cordova.hasPermission(permissions[TAKE_PIC_SEC])) {
             takePicture(returnType, encodingType);
         } else {
             PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);

--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -17,11 +17,13 @@
 package org.apache.cordova.camera;
 
 import android.annotation.SuppressLint;
+import android.content.ContentUris;
 import android.content.Context;
 import android.content.CursorLoader;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.webkit.MimeTypeMap;
@@ -57,10 +59,6 @@ public class FileHelper {
         else if (Build.VERSION.SDK_INT < 19)
             realPath = FileHelper.getRealPathFromURI_API11to18(cordova.getActivity(), uri);
 
-        //is not document uri
-        else if(!DocumentsContract.isDocumentUri(cordova.getActivity(),uri))
-            realPath = FileHelper.getRealPathFromURI_API11to18(cordova.getActivity(), uri);
-
         // SDK > 19 (Android 4.4)
         else
             realPath = FileHelper.getRealPathFromURI_API19(cordova.getActivity(), uri);
@@ -80,30 +78,137 @@ public class FileHelper {
         return FileHelper.getRealPath(Uri.parse(uriString), cordova);
     }
 
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     * @author paulburke
+     */
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     * @author paulburke
+     */
+    private static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     * @author paulburke
+     */
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Photos.
+     */
+    private static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
+
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     * @param selection (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     * @author paulburke
+     */
+    private static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
     @SuppressLint("NewApi")
-    public static String getRealPathFromURI_API19(Context context, Uri uri) {
+    public static String getRealPathFromURI_API19(final Context context, final Uri uri) {
         String filePath = "";
         try {
-            String wholeID = DocumentsContract.getDocumentId(uri);
+            // DocumentProvider
+            if (DocumentsContract.isDocumentUri(context, uri)) {
+                if (isExternalStorageDocument(uri)) {
+                    final String docId = DocumentsContract.getDocumentId(uri);
+                    final String[] split = docId.split(":");
+                    final String type = split[0];
 
-            // Split at colon, use second item in the array
-            String id = wholeID.indexOf(":") > -1 ? wholeID.split(":")[1] : wholeID.indexOf(";") > -1 ? wholeID
-                    .split(";")[1] : wholeID;
+                    if ("primary".equalsIgnoreCase(type)) {
+                        return Environment.getExternalStorageDirectory() + "/" + split[1];
+                    }
 
-            String[] column = { MediaStore.Images.Media.DATA };
+                    // TODO handle non-primary volumes
+                }
+                // DownloadsProvider
+                else if (isDownloadsDocument(uri)) {
 
-            // where id is equal to
-            String sel = MediaStore.Images.Media._ID + "=?";
+                    final String id = DocumentsContract.getDocumentId(uri);
+                    final Uri contentUri = ContentUris.withAppendedId(
+                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
 
-            Cursor cursor = context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, column,
-                    sel, new String[] { id }, null);
+                    return getDataColumn(context, contentUri, null, null);
+                }
+                // MediaProvider
+                else if (isMediaDocument(uri)) {
+                    final String docId = DocumentsContract.getDocumentId(uri);
+                    final String[] split = docId.split(":");
+                    final String type = split[0];
 
-            int columnIndex = cursor.getColumnIndex(column[0]);
+                    Uri contentUri = null;
+                    if ("image".equals(type)) {
+                        contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                    } else if ("video".equals(type)) {
+                        contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                    } else if ("audio".equals(type)) {
+                        contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                    }
 
-            if (cursor.moveToFirst()) {
-                filePath = cursor.getString(columnIndex);
+                    final String selection = "_id=?";
+                    final String[] selectionArgs = new String[] {
+                            split[1]
+                    };
+
+                    return getDataColumn(context, contentUri, selection, selectionArgs);
+                }
             }
-            cursor.close();
+            // MediaStore (and general)
+            else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+                // Return the remote address
+                if (isGooglePhotosUri(uri))
+                    return uri.getLastPathSegment();
+
+                return getDataColumn(context, uri, null, null);
+            }
+            // File
+            else if ("file".equalsIgnoreCase(uri.getScheme())) {
+                return uri.getPath();
+            }
         } catch (Exception e) {
             filePath = "";
         }
@@ -213,7 +318,7 @@ public class FileHelper {
         }
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
     }
-    
+
     /**
      * Returns the mime type of the data specified by the given URI string.
      *

--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -57,6 +57,10 @@ public class FileHelper {
         else if (Build.VERSION.SDK_INT < 19)
             realPath = FileHelper.getRealPathFromURI_API11to18(cordova.getActivity(), uri);
 
+        //is not document uri
+        else if(!DocumentsContract.isDocumentUri(cordova.getActivity(),uri))
+            realPath = FileHelper.getRealPathFromURI_API11to18(cordova.getActivity(), uri);
+
         // SDK > 19 (Android 4.4)
         else
             realPath = FileHelper.getRealPathFromURI_API19(cordova.getActivity(), uri);

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -80,6 +80,10 @@ typedef NSUInteger CDVMediaType;
 
 // ======================================================================= //
 
+typedef void(^CDVCameraReadMetadataCompletionBlock)(UIImage*, NSDictionary*, CDVPictureOptions*);
+typedef void(^CDVCameraProcessImageResultBlock)(UIImage*, NSDictionary*, NSURL*);
+typedef void(^CDVCameraProcessImageFailureBlock)(NSString*);
+
 @interface CDVCamera : CDVPlugin <UIImagePickerControllerDelegate,
                        UINavigationControllerDelegate,
                        UIPopoverControllerDelegate,
@@ -87,19 +91,19 @@ typedef NSUInteger CDVMediaType;
 {}
 
 @property (strong) CDVCameraPicker* pickerController;
-@property (strong) NSMutableDictionary *metadata;
+@property (strong) NSDictionary* metadata;
 @property (strong, nonatomic) CLLocationManager *locationManager;
-@property (strong) NSData* data;
+@property (strong) UIImage* image;
 
 /*
  * getPicture
  *
  * arguments:
- *	1: this is the javascript function that will be called with the results, the first parameter passed to the
- *		javascript function is the picture as a Base64 encoded string
+ *  1: this is the javascript function that will be called with the results, the first parameter passed to the
+ *    javascript function is the picture as a Base64 encoded string
  *  2: this is the javascript function to be called if there was an error
  * options:
- *	quality: integer between 1 and 100
+ *  quality: integer between 1 and 100
  */
 - (void)takePicture:(CDVInvokedUrlCommand*)command;
 - (void)cleanup:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -217,8 +217,10 @@ static NSString* toBase64(NSData* data) {
         BOOL needsResize = [self needsResize:pictureOptions];
         BOOL needsOrientationCorrection = pictureOptions.correctOrientation;
         BOOL isSourceCamera = (pictureOptions.sourceType == UIImagePickerControllerSourceTypeCamera);
-        BOOL needsSavingToPhotoAlbum = (isSourceCamera || needsResize || needsOrientationCorrection);
+        BOOL allowsEditing = pictureOptions.allowsEditing;
+        BOOL needsSavingToPhotoAlbum = (isSourceCamera || needsResize || needsOrientationCorrection || allowsEditing);
         
+        // if one wants an edited image and a NATIVE_URI, the edited image must be in the assets library therefore one must set the saveToPhotoAlbum option to true.
         if (!pictureOptions.saveToPhotoAlbum && isDestinationNativeUri && needsSavingToPhotoAlbum) {
             NSLog(@"Incompatible options, cannot return native URI if image is not in the assets library");
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Incompatible options, cannot return native URI if image is not in the assets library"];

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -42,7 +42,7 @@ static NSString* toBase64(NSData* data) {
     SEL s1 = NSSelectorFromString(@"cdv_base64EncodedString");
     SEL s2 = NSSelectorFromString(@"base64EncodedString");
     SEL s3 = NSSelectorFromString(@"base64EncodedStringWithOptions:");
-    
+
     if ([data respondsToSelector:s1]) {
         NSString* (*func)(id, SEL) = (void *)[data methodForSelector:s1];
         return func(data, s1);
@@ -108,7 +108,7 @@ static NSString* toBase64(NSData* data) {
  - metadata for captured image
  - metadata for gallery image
  - when saving to album, save metadata too
- 
+
  Metadata must take into account orientation fixes and resize
  */
 
@@ -119,7 +119,7 @@ static NSString* toBase64(NSData* data) {
     pictureOptions.quality = [command argumentAtIndex:0 withDefault:@(50)];
     pictureOptions.destinationType = [[command argumentAtIndex:1 withDefault:@(DestinationTypeFileUri)] unsignedIntegerValue];
     pictureOptions.sourceType = [[command argumentAtIndex:2 withDefault:@(UIImagePickerControllerSourceTypeCamera)] unsignedIntegerValue];
-    
+
     NSNumber* targetWidth = [command argumentAtIndex:3 withDefault:nil];
     NSNumber* targetHeight = [command argumentAtIndex:4 withDefault:nil];
     pictureOptions.targetSize = CGSizeMake(0, 0);
@@ -134,10 +134,10 @@ static NSString* toBase64(NSData* data) {
     pictureOptions.saveToPhotoAlbum = [[command argumentAtIndex:9 withDefault:@(NO)] boolValue];
     pictureOptions.popoverOptions = [command argumentAtIndex:10 withDefault:nil];
     pictureOptions.cameraDirection = [[command argumentAtIndex:11 withDefault:@(UIImagePickerControllerCameraDeviceRear)] unsignedIntegerValue];
-    
+
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;
-    
+
     return pictureOptions;
 }
 
@@ -162,7 +162,7 @@ static NSString* toBase64(NSData* data) {
 - (NSURL*) urlTransformer:(NSURL*)url
 {
     NSURL* urlToTransform = url;
-    
+
     // for backwards compatibility - we check if this property is there
     SEL sel = NSSelectorFromString(@"urlTransformer");
     if ([self.commandDelegate respondsToSelector:sel]) {
@@ -173,7 +173,7 @@ static NSString* toBase64(NSData* data) {
             urlToTransform = urlTransformer(url);
         }
     }
-    
+
     return urlToTransform;
 }
 
@@ -192,13 +192,13 @@ static NSString* toBase64(NSData* data) {
 - (void)takePicture:(CDVInvokedUrlCommand*)command
 {
     self.hasPendingOperation = YES;
-    
+
     __weak CDVCamera* weakSelf = self;
 
     [self.commandDelegate runInBackground:^{
-        
+
         CDVPictureOptions* pictureOptions = [CDVPictureOptions createFromTakePictureArguments:command];
-        
+
         /*
          FIXME #1
          What to do about quality?
@@ -213,13 +213,13 @@ static NSString* toBase64(NSData* data) {
          */
         // Check for option compatibility
         BOOL isDestinationNativeUri = (pictureOptions.destinationType == DestinationTypeNativeUri);
-        
+
         BOOL needsResize = [self needsResize:pictureOptions];
         BOOL needsOrientationCorrection = pictureOptions.correctOrientation;
         BOOL isSourceCamera = (pictureOptions.sourceType == UIImagePickerControllerSourceTypeCamera);
         BOOL allowsEditing = pictureOptions.allowsEditing;
         BOOL needsSavingToPhotoAlbum = (isSourceCamera || needsResize || needsOrientationCorrection || allowsEditing);
-        
+
         // if one wants an edited image and a NATIVE_URI, the edited image must be in the assets library therefore one must set the saveToPhotoAlbum option to true.
         if (!pictureOptions.saveToPhotoAlbum && isDestinationNativeUri && needsSavingToPhotoAlbum) {
             NSLog(@"Incompatible options, cannot return native URI if image is not in the assets library");
@@ -227,10 +227,10 @@ static NSString* toBase64(NSData* data) {
             [weakSelf.commandDelegate sendPluginResult:result callbackId:command.callbackId];
             return;
         }
-        
+
         pictureOptions.popoverSupported = [weakSelf popoverSupported];
         pictureOptions.usesGeolocation = [weakSelf usesGeolocation];
-        
+
         BOOL hasCamera = [UIImagePickerController isSourceTypeAvailable:pictureOptions.sourceType];
         if (!hasCamera) {
             NSLog(@"Camera.getPicture: source type %lu not available.", (unsigned long)pictureOptions.sourceType);
@@ -266,12 +266,12 @@ static NSString* toBase64(NSData* data) {
 
         CDVCameraPicker* cameraPicker = [CDVCameraPicker createFromPictureOptions:pictureOptions];
         weakSelf.pickerController = cameraPicker;
-        
+
         cameraPicker.delegate = weakSelf;
         cameraPicker.callbackId = command.callbackId;
         // we need to capture this state for memory warnings that dealloc this object
         cameraPicker.webView = weakSelf.webView;
-        
+
         // Perform UI operations on the main thread
         dispatch_async(dispatch_get_main_queue(), ^{
             // If a popover is already open, close it; we only want one at a time.
@@ -369,7 +369,7 @@ static NSString* toBase64(NSData* data) {
 {
     if([navigationController isKindOfClass:[UIImagePickerController class]]){
         UIImagePickerController* cameraPicker = (UIImagePickerController*)navigationController;
-        
+
         if(![cameraPicker.mediaTypes containsObject:(NSString*)kUTTypeImage]){
             [viewController.navigationItem setTitle:NSLocalizedString(@"Videos", nil)];
         }
@@ -431,13 +431,13 @@ static NSString* toBase64(NSData* data) {
     NSString* docsPath = [NSTemporaryDirectory()stringByStandardizingPath];
     NSFileManager* fileMgr = [[NSFileManager alloc] init]; // recommended by Apple (vs [NSFileManager defaultManager]) to be threadsafe
     NSString* filePath;
-    
+
     // generate unique file name
     int i = 1;
     do {
         filePath = [NSString stringWithFormat:@"%@/%@%03d.%@", docsPath, CDV_PHOTO_PREFIX, i++, extension];
     } while ([fileMgr fileExistsAtPath:filePath]);
-    
+
     return filePath;
 }
 
@@ -472,7 +472,7 @@ static NSString* toBase64(NSData* data) {
      */
     BOOL isSourceCamera = options.sourceType == UIImagePickerControllerSourceTypeCamera;
     BOOL saveToPhotoAlbum = options.saveToPhotoAlbum && ([self needsEdit:image options:options] || isSourceCamera);
-    
+
     return saveToPhotoAlbum;
 }
 
@@ -481,7 +481,7 @@ static NSString* toBase64(NSData* data) {
  - source: gallery
  - destination: NATIVE_URI
  - no edit (not orientation and not resize and not allowEdits)
- 
+
  otherwise, it can be found:
  - source: camera
  => UIImagePickerControllerMediaMetadata
@@ -504,7 +504,7 @@ static NSString* toBase64(NSData* data) {
 - (void)didReceiveImage:(CDVPictureOptions*)options info:(NSDictionary*)info
 {
     UIImage* image = [self retrieveImage:info options:options];
-    
+
     /*
      We can send the result immediately if:
      - we fetch the picture from the PhotoLibrary or the SavedPhotoAlbum,
@@ -522,7 +522,7 @@ static NSString* toBase64(NSData* data) {
         [self sendResult:result];
         return;
     }
-    
+
     __weak CDVCamera* weakSelf = self;
     CDVCameraReadMetadataCompletionBlock metadataCompletionBlock;
     metadataCompletionBlock = ^(UIImage *image, NSDictionary *metadata, CDVPictureOptions *options){
@@ -566,14 +566,14 @@ static NSString* toBase64(NSData* data) {
 {
     CGRect cropRect = [[info objectForKey:UIImagePickerControllerCropRect] CGRectValue];
     NSMutableDictionary* mutableMetadata = [metadata mutableCopy];
-    
+
     [mutableMetadata setValue:[NSNumber numberWithFloat:cropRect.size.width] forKey:(NSString*)kCGImagePropertyPixelWidth];
     [mutableMetadata setValue:[NSNumber numberWithFloat:cropRect.size.height] forKey:(NSString*)kCGImagePropertyPixelHeight];
     // orientation: 1 == TopLeft
     // allowsEditing simply allows to crop the image into a square..
     // front facing camera seemingly flips the picture..
     [mutableMetadata setValue:[NSNumber numberWithInt:1] forKey:(NSString*)kCGImagePropertyOrientation];
-    
+
     return mutableMetadata;
 }
 
@@ -603,13 +603,13 @@ static NSString* toBase64(NSData* data) {
         ];
         return;
     }
-    
+
     NSDictionary* metadata = [info objectForKey:UIImagePickerControllerMediaMetadata];
-    
+
     if (options.allowsEditing) {
         metadata = [self fixMetadataForEdited:metadata info:info];
     }
-    
+
     completionBlock(image, metadata, options);
 }
 
@@ -626,31 +626,31 @@ static NSString* toBase64(NSData* data) {
 - (void)fixOrientation:(UIImage**)image metadata:(NSDictionary**)metadata
 {
     NSMutableDictionary *mutableMetadata = [*metadata mutableCopy];
-    
+
     // Get image width and height before orientation correction...
     NSNumber *pixelWidth = [mutableMetadata valueForKey:(NSString*)kCGImagePropertyPixelWidth];
     NSNumber *pixelHeight = [mutableMetadata valueForKey:(NSString*)kCGImagePropertyPixelHeight];
     // ...as well as orientation
     long oldOrientation = [(NSNumber*)[mutableMetadata valueForKey:(NSString*)kCGImagePropertyOrientation] integerValue];
-    
+
     // Do the orientation correction
     *image = [*image imageCorrectedForCaptureOrientation];
-    
+
     // Reflect orientation correction (1 means default orientation)
     [mutableMetadata setValue:[NSNumber numberWithInt:1] forKey:(__bridge NSString*)kCGImagePropertyOrientation];
-    
+
     BOOL needsDimensionsInverting = (oldOrientation >=5 && oldOrientation <= 8);
     // If orientation correction inverted width and height dimensions, reflect that on metadata
     if (needsDimensionsInverting) {
         if (pixelHeight != nil) {
             [mutableMetadata setValue:pixelHeight forKey:(NSString*)kCGImagePropertyPixelWidth];
         }
-        
+
         if (pixelWidth != nil) {
             [mutableMetadata setValue:pixelWidth forKey:(NSString*)kCGImagePropertyPixelHeight];
         }
     }
-    
+
     *metadata = [NSDictionary dictionaryWithDictionary:mutableMetadata];
 }
 
@@ -658,15 +658,15 @@ static NSString* toBase64(NSData* data) {
 {
     UIImage* scaledImage = [*image imageByScalingNotCroppingForSize:size];
     NSMutableDictionary *mutableMetadata = [*metadata mutableCopy];
-    
+
     // Reflect dimensions change on metadata
     if (scaledImage != nil && mutableMetadata != nil) {
         [mutableMetadata setValue:[NSNumber numberWithFloat:(*image).size.width] forKey:(NSString*)kCGImagePropertyPixelWidth];
         [mutableMetadata setValue:[NSNumber numberWithFloat:(*image).size.height] forKey:(NSString*)kCGImagePropertyPixelHeight];
     }
-    
+
     *metadata = [NSDictionary dictionaryWithDictionary:mutableMetadata];
-    
+
     if (scaledImage != nil) {
         *image = scaledImage;
     }
@@ -683,15 +683,15 @@ static NSString* toBase64(NSData* data) {
     if ([self needsOrientationCorrection:image options:options]) {
         [self fixOrientation:&image metadata:&metadata];
     }
-    
+
     if ([self needsResize:options]) {
         [self resizeImage:&image metadata:&metadata size:options.targetSize];
     }
-    
+
     if ([self needsSavingToPhotoAlbum:image options:options]) {
         BOOL isSourceCamera = options.sourceType == UIImagePickerControllerSourceTypeCamera;
         BOOL isDestinationNativeUri = options.destinationType == DestinationTypeNativeUri;
-        
+
         ALAssetsLibraryWriteImageCompletionBlock librarySaveCompletionBlock = nil;
         // if source is camera and destination is NATIVE_URI:
         // we need to return the url of the asset we've just created.. otherwise we can't return a NATIVE_URI
@@ -707,22 +707,22 @@ static NSString* toBase64(NSData* data) {
                 resultBlock(nil, nil, assetURL);
             };
         }
-        
+
         [self saveToPhotoAlbum:image metadata:metadata completionBlock:librarySaveCompletionBlock];
-    
+
         // if there is a completion block we know we will send the result at some point (ie the completionBlock has fired) so stop here..
         if (librarySaveCompletionBlock != nil) {
             return;
         }
     }
-    
+
     resultBlock(image, metadata, nil);
 }
 
 - (NSData*)imageToData:(UIImage*)image metadata:(NSDictionary*)metadata options:(CDVPictureOptions*)options
 {
     NSData *imageData = UIImageJPEGRepresentation(image, [options.quality floatValue] / 100.0f);
-    
+
     // Create source image reference
     CGImageSourceRef source;
     source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -730,10 +730,10 @@ static NSString* toBase64(NSData* data) {
         NSLog(@"***Could not create source destination ***");
         return imageData;
     }
-    
+
     // Get image type
     CFStringRef UTI = CGImageSourceGetType(source);
-    
+
     // Create destination image reference using mutable data
     NSMutableData *mutableDestinationData = [NSMutableData data];
     CGImageDestinationRef destination;
@@ -742,20 +742,20 @@ static NSString* toBase64(NSData* data) {
         NSLog(@"***Could not create image destination ***");
         return imageData;
     }
-    
+
     CGImageDestinationAddImageFromSource(destination, source, 0, (CFDictionaryRef)metadata);
-    
+
     BOOL success = NO;
     success = CGImageDestinationFinalize(destination);
     if (!success) {
         NSLog(@"***Could not create data from image destination ***");
         return imageData;
     }
-    
+
     // Cleanup
     CFRelease(destination);
     CFRelease(source);
-    
+
     // Return a non-mutable copy of the destination image data
     return [NSData dataWithData:(NSData *)mutableDestinationData];
 }
@@ -812,7 +812,7 @@ static NSString* toBase64(NSData* data) {
         NSString* extension = options.encodingType == EncodingTypePNG ? @"png" : @"jpg";
         NSString* filePath = [self tempFilePath:extension];
         NSError* err = nil;
-        
+
         // save file
         if (![imageData writeToFile:filePath options:NSAtomicWrite error:&err]) {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsString:[err localizedDescription]];
@@ -844,7 +844,7 @@ static NSString* toBase64(NSData* data) {
     if (result) {
         [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
     }
-    
+
     self.hasPendingOperation = NO;
     self.pickerController = nil;
     self.image = nil;
@@ -861,34 +861,20 @@ static NSString* toBase64(NSData* data) {
 {
     __weak CDVCameraPicker* cameraPicker = (CDVCameraPicker*)picker;
     __weak CDVCamera* weakSelf = self;
-    
+
     dispatch_block_t invoke = ^(void) {
         __block CDVPluginResult* result = nil;
-        
+
         NSString* mediaType = [info objectForKey:UIImagePickerControllerMediaType];
         if ([mediaType isEqualToString:(NSString*)kUTTypeImage]) {
-<<<<<<< a060fb36f38b5dcf9daab64bbbfcda0b1646a817
-            [weakSelf resultForImage:cameraPicker.pictureOptions info:info completion:^(CDVPluginResult* res) {
-                [weakSelf.commandDelegate sendPluginResult:res callbackId:cameraPicker.callbackId];
-                weakSelf.hasPendingOperation = NO;
-                weakSelf.pickerController = nil;
-            }];
-        }
-        else {
-            result = [weakSelf resultForVideo:info];
-            [weakSelf.commandDelegate sendPluginResult:result callbackId:cameraPicker.callbackId];
-            weakSelf.hasPendingOperation = NO;
-            weakSelf.pickerController = nil;
-=======
             [weakSelf didReceiveImage:cameraPicker.pictureOptions info:info];
         }
         else {
             result = [self resultForVideo:info];
             [weakSelf sendResult:result];
->>>>>>> Major refactor
         }
     };
-    
+
     if (cameraPicker.pictureOptions.popoverSupported && (cameraPicker.pickerPopoverController != nil)) {
         [cameraPicker.pickerPopoverController dismissPopoverAnimated:YES];
         cameraPicker.pickerPopoverController.delegate = nil;
@@ -911,7 +897,7 @@ static NSString* toBase64(NSData* data) {
 {
     __weak CDVCameraPicker* cameraPicker = (CDVCameraPicker*)picker;
     __weak CDVCamera* weakSelf = self;
-    
+
     dispatch_block_t invoke = ^ (void) {
         CDVPluginResult* result;
         if ([ALAssetsLibrary authorizationStatus] == ALAuthorizationStatusAuthorized) {
@@ -919,9 +905,9 @@ static NSString* toBase64(NSData* data) {
         } else {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to assets"];
         }
-        
+
         [weakSelf.commandDelegate sendPluginResult:result callbackId:cameraPicker.callbackId];
-        
+
         weakSelf.hasPendingOperation = NO;
         weakSelf.pickerController = nil;
     };
@@ -934,11 +920,11 @@ static NSString* toBase64(NSData* data) {
 	if (locationManager != nil) {
 		return locationManager;
 	}
-    
+
 	locationManager = [[CLLocationManager alloc] init];
 	[locationManager setDesiredAccuracy:kCLLocationAccuracyNearestTenMeters];
 	[locationManager setDelegate:self];
-    
+
 	return locationManager;
 }
 
@@ -947,15 +933,15 @@ static NSString* toBase64(NSData* data) {
     if (locationManager == nil) {
         return;
     }
-    
+
     [self.locationManager stopUpdatingLocation];
     self.locationManager = nil;
-    
+
     NSMutableDictionary *GPSDictionary = [[NSMutableDictionary dictionary] init];
-    
+
     CLLocationDegrees latitude  = newLocation.coordinate.latitude;
     CLLocationDegrees longitude = newLocation.coordinate.longitude;
-    
+
     // latitude
     if (latitude < 0.0) {
         latitude = latitude * -1.0f;
@@ -964,7 +950,7 @@ static NSString* toBase64(NSData* data) {
         [GPSDictionary setObject:@"N" forKey:(NSString*)kCGImagePropertyGPSLatitudeRef];
     }
     [GPSDictionary setObject:[NSNumber numberWithFloat:latitude] forKey:(NSString*)kCGImagePropertyGPSLatitude];
-    
+
     // longitude
     if (longitude < 0.0) {
         longitude = longitude * -1.0f;
@@ -974,7 +960,7 @@ static NSString* toBase64(NSData* data) {
         [GPSDictionary setObject:@"E" forKey:(NSString*)kCGImagePropertyGPSLongitudeRef];
     }
     [GPSDictionary setObject:[NSNumber numberWithFloat:longitude] forKey:(NSString*)kCGImagePropertyGPSLongitude];
-    
+
     // altitude
     CGFloat altitude = newLocation.altitude;
     if (!isnan(altitude)){
@@ -986,7 +972,7 @@ static NSString* toBase64(NSData* data) {
         }
         [GPSDictionary setObject:[NSNumber numberWithFloat:altitude] forKey:(NSString *)kCGImagePropertyGPSAltitude];
     }
-    
+
     // Time and date
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateFormat:@"HH:mm:ss.SSSSSS"];
@@ -994,11 +980,11 @@ static NSString* toBase64(NSData* data) {
     [GPSDictionary setObject:[formatter stringFromDate:newLocation.timestamp] forKey:(NSString *)kCGImagePropertyGPSTimeStamp];
     [formatter setDateFormat:@"yyyy:MM:dd"];
     [GPSDictionary setObject:[formatter stringFromDate:newLocation.timestamp] forKey:(NSString *)kCGImagePropertyGPSDateStamp];
-    
+
     NSMutableDictionary* mutableMetadata = [self.metadata mutableCopy];
-    
+
     [mutableMetadata setObject:GPSDictionary forKey:(NSString *)kCGImagePropertyGPSDictionary];
-    
+
     __weak CDVCamera* weakSelf = self;
     [self
      processImage:self.image
@@ -1027,7 +1013,7 @@ static NSString* toBase64(NSData* data) {
 
     [self.locationManager stopUpdatingLocation];
     self.locationManager = nil;
-    
+
     __weak CDVCamera* weakSelf = self;
     [self
      processImage:self.image
@@ -1061,14 +1047,14 @@ static NSString* toBase64(NSData* data) {
 {
     return nil;
 }
-    
+
 - (void)viewWillAppear:(BOOL)animated
 {
     SEL sel = NSSelectorFromString(@"setNeedsStatusBarAppearanceUpdate");
     if ([self respondsToSelector:sel]) {
         [self performSelector:sel withObject:nil afterDelay:0];
     }
-    
+
     [super viewWillAppear:animated];
 }
 
@@ -1078,7 +1064,7 @@ static NSString* toBase64(NSData* data) {
     cameraPicker.pictureOptions = pictureOptions;
     cameraPicker.sourceType = pictureOptions.sourceType;
     cameraPicker.allowsEditing = pictureOptions.allowsEditing;
-    
+
     if (cameraPicker.sourceType == UIImagePickerControllerSourceTypeCamera) {
         // We only allow taking pictures (no video) in this API.
         cameraPicker.mediaTypes = @[(NSString*)kUTTypeImage];
@@ -1090,7 +1076,7 @@ static NSString* toBase64(NSData* data) {
         NSArray* mediaArray = @[(NSString*)(pictureOptions.mediaType == MediaTypeVideo ? kUTTypeMovie : kUTTypeImage)];
         cameraPicker.mediaTypes = mediaArray;
     }
-    
+
     return cameraPicker;
 }
 

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -900,10 +900,12 @@ static NSString* toBase64(NSData* data) {
 
     dispatch_block_t invoke = ^ (void) {
         CDVPluginResult* result;
-        if ([ALAssetsLibrary authorizationStatus] == ALAuthorizationStatusAuthorized) {
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no image selected"];
-        } else {
+        if (picker.sourceType == UIImagePickerControllerSourceTypeCamera && [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] != ALAuthorizationStatusAuthorized) {
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to camera"];
+        } else if (picker.sourceType != UIImagePickerControllerSourceTypeCamera && [ALAssetsLibrary authorizationStatus] != ALAuthorizationStatusAuthorized) {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to assets"];
+        } else {
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no image selected"];
         }
 
         [weakSelf.commandDelegate sendPluginResult:result callbackId:cameraPicker.callbackId];

--- a/tests/ios/CDVCameraTest/CDVCameraLibTests/CameraTest.m
+++ b/tests/ios/CDVCameraTest/CDVCameraLibTests/CameraTest.m
@@ -297,11 +297,13 @@
     
     // test 640x480
     
-    targetSize = CGSizeMake(640, 480);
+    targetSize = CGSizeMake(480, 640);
     
     targetImage = [sourceImagePortrait imageByScalingNotCroppingForSize:targetSize];
     XCTAssertEqual(targetImage.size.width, targetSize.width);
     XCTAssertEqual(targetImage.size.height, targetSize.height);
+
+    targetSize = CGSizeMake(640, 480);
     
     targetImage = [sourceImageLandscape imageByScalingNotCroppingForSize:targetSize];
     XCTAssertEqual(targetImage.size.width, targetSize.width);
@@ -310,11 +312,13 @@
     
     // test 800x600
     
-    targetSize = CGSizeMake(800, 600);
+    targetSize = CGSizeMake(600, 800);
     
     targetImage = [sourceImagePortrait imageByScalingNotCroppingForSize:targetSize];
     XCTAssertEqual(targetImage.size.width, targetSize.width);
     XCTAssertEqual(targetImage.size.height, targetSize.height);
+    
+    targetSize = CGSizeMake(800, 600);
     
     targetImage = [sourceImageLandscape imageByScalingNotCroppingForSize:targetSize];
     XCTAssertEqual(targetImage.size.width, targetSize.width);
@@ -322,11 +326,13 @@
     
     // test 1024x768
     
-    targetSize = CGSizeMake(1024, 768);
+    targetSize = CGSizeMake(768, 1024);
     
     targetImage = [sourceImagePortrait imageByScalingNotCroppingForSize:targetSize];
     XCTAssertEqual(targetImage.size.width, targetSize.width);
     XCTAssertEqual(targetImage.size.height, targetSize.height);
+    
+    targetSize = CGSizeMake(1024, 768);
     
     targetImage = [sourceImageLandscape imageByScalingNotCroppingForSize:targetSize];
     XCTAssertEqual(targetImage.size.width, targetSize.width);


### PR DESCRIPTION
Hi there,

We needed access to the metadata which lead to asynchronous operations. We took the opportunity to refactor most of the plugin logic. Hopefully it's more readable and actually fixes some known bugs (e.g. we deal properly with NATIVE_URI wherever possible).

This is a call for feedback and testing while I try to fix a known bug.

The commit message is quite explicit, so here it is:

---
The major thing added here is that metadata is correctly handled in most (all?) cases. I also think some bugs have been fixed, but I did not check the bug list ;)

As a foreword, I want to say that I am far from being an expert in either Objective-C nor the iOS APIs (I only did some basic patches before). So please correct me if I say/did anything wrong.

# Global flow
As a general design decision, I tried to break all the workflow in small readable methods that either return something (I chose to use reference passing when returning more than one result which I find clearer than returning an NSDictionary where the result is specified nowhere), or use the convention completionBlock / resultBlock / failureBlock which it seems Apple APIs use.

There are three main paths from the image retrieval to the result.

1. The user wants the original image from the PhotoLibrary or from the SavedPhotoAlbum with a destination type NATIVE_URI.
2. The user wants a modified version of the image, wherever it comes from.
3. The user wants the geolocation.

# Option incompatibilities
There are also some combinations of options that are disallowed because they don’t make any sense:

1. if the user wants an image with a source type CAMERA, and a destination type NATIVE_URI, he has to save it to the photo album. An image that is not there does not have a NATIVE_URI.
2. if the user wants an image with a source type PHOTOLIBRARY or SAVEDPHOTOALBUM, needs editing (resize, orientation correction), and a destination type NATIVE_URI, he has to save it to the photo album. Otherwise, we would return the original image with no modification.

As we can see, if we want a destination type of NATIVE_URI, there are only two possible paths: either we want an unmodified version of a library image, or we need to save to the photo album.

# Metadata
Regarding metadata, we do not need it in only one case, when the destination type is NATIVE_URI, the source is the library, and no edits have to be done.

Otherwise, we need to either fetch if from the UIImagePickerControllerMediaMetadata key of the info dictionary provided by UIImagePickerController in case the source type is CAMERA, or from the ALAsset corresponding to the library image (see https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImagePickerControllerDelegate_Protocol/index.html#//apple_ref/doc/constant_group/Editing_Information_Keys).  
This actually introduces asynchronicity in the metadata retrieval, since we first need to fetch the ALAsset using UIImagePickerControllerReferenceURL. *We cannot use UIImage as it strips out most (all?) of the metadata*.

Once we actually retrieved the metadata we need to modify it for every transformation of the image (orientation, resize, gps).

# Saving to the Photo Album
In the previous code, the saving was done after computing the CDVResult. This is not the case anymore as we need access to the saved ALAsset when we want to return a NATIVE_URI. The saving is now done after all image editing has occurred.

# Asynchronous processing
Since the metadata retrieval and the album saving is done asynchronously, the process pipeline itself is made asynchronous. We can use resultBlock and failureBlock to get the processed image with its corresponding metadata or to get the image Asset NATIVE_URI.

# FIXMEs
The documentation lacks some clarity for two things (see FIXME 1 & 2 in code):

-  Does the quality option apply to the library images as well. This would mean that we cannot use NATIVE_URI with the quality set, except if we save to the photo album.
- Does the orientation correction apply to the library images as well. Same thing. I actually removed that options at first, but this would mean that we need to read the EXIF data in the js code and orient the image appropriately (except for NATIVE_URIs since the web view does that automagically, but orientation correction does not make sense here). 

# TODOs
- [ ] usesGeolocation does not make sense for an image with a source type other that CAMERA (maybe on some fringe cases?)
- [x] fix a bug where allowsEdit + saveToPhotoAlbum + NATIVE_URI make the image save in the wrong orientation (despite the metadata having the correct orientation afaict)

__WARNING:__
I did not test the usesGeolocation option due to a lack of time (and, frankly, a lack of interest ;).

__ACKNOWLEDGMENT:__
Shoutout to @athibaud who also took part in the refactoring effort. Any bug’s on him! ;)