### PR TITLE
CB-9193: Add 'showLibraryButton' to allow choosing source

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,20 @@ Documentation consists of template and API docs produced from the plugin JS code
 
 
 * [camera](#module_camera)
-  * [.getPicture(successCallback, errorCallback, options)](#module_camera.getPicture)
-  * [.cleanup()](#module_camera.cleanup)
-  * [.onError](#module_camera.onError) : <code>function</code>
-  * [.onSuccess](#module_camera.onSuccess) : <code>function</code>
-  * [.CameraOptions](#module_camera.CameraOptions) : <code>Object</code>
+    * [.getPicture(successCallback, errorCallback, options)](#module_camera.getPicture)
+    * [.cleanup()](#module_camera.cleanup)
+    * [.onError](#module_camera.onError) : <code>function</code>
+    * [.onSuccess](#module_camera.onSuccess) : <code>function</code>
+    * [.CameraOptions](#module_camera.CameraOptions) : <code>Object</code>
 
 
 * [Camera](#module_Camera)
-  * [.DestinationType](#module_Camera.DestinationType) : <code>enum</code>
-  * [.EncodingType](#module_Camera.EncodingType) : <code>enum</code>
-  * [.MediaType](#module_Camera.MediaType) : <code>enum</code>
-  * [.PictureSourceType](#module_Camera.PictureSourceType) : <code>enum</code>
-  * [.PopoverArrowDirection](#module_Camera.PopoverArrowDirection) : <code>enum</code>
-  * [.Direction](#module_Camera.Direction) : <code>enum</code>
+    * [.DestinationType](#module_Camera.DestinationType) : <code>enum</code>
+    * [.EncodingType](#module_Camera.EncodingType) : <code>enum</code>
+    * [.MediaType](#module_Camera.MediaType) : <code>enum</code>
+    * [.PictureSourceType](#module_Camera.PictureSourceType) : <code>enum</code>
+    * [.PopoverArrowDirection](#module_Camera.PopoverArrowDirection) : <code>enum</code>
+    * [.Direction](#module_Camera.Direction) : <code>enum</code>
 
 * [CameraPopoverHandle](#module_CameraPopoverHandle)
 * [CameraPopoverOptions](#module_CameraPopoverOptions)
@@ -229,6 +229,7 @@ Optional parameters to customize the camera settings.
 | saveToPhotoAlbum | <code>Boolean</code> |  | Save the image to the photo album on the device after capture. |
 | popoverOptions | <code>[CameraPopoverOptions](#module_CameraPopoverOptions)</code> |  | iOS-only options that specify popover location in iPad. |
 | cameraDirection | <code>[Direction](#module_Camera.Direction)</code> | <code>BACK</code> | Choose the camera to use (front- or back-facing). |
+| showLibraryButton | <code>Boolean</code> |  | Shows an option to choose an image from their photo library in addition to the camera. Only works when `PictureSourceType` is `CAMERA`. |
 
 ---
 
@@ -448,6 +449,8 @@ Tizen only supports a `destinationType` of
 
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
 
+- Ignores the `showLibraryButton` parameter.
+
 #### Android Quirks
 
 - Any `cameraDirection` value results in a back-facing photo.
@@ -457,6 +460,8 @@ Tizen only supports a `destinationType` of
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
 
 - Ignores the `encodingType` parameter if the image is unedited (i.e. `quality` is 100, `correctOrientation` is false, and no `targetHeight` or `targetWidth` are specified). The `CAMERA` source will always return the JPEG file given by the native camera and the `PHOTOLIBRARY` and `SAVEDPHOTOALBUM` sources will return the selected file in its existing encoding.
+
+- When `showLibraryButton` is `true`, an Intent chooser is displayed which lists all possible handlers for either the Camera or File chooser -- and the user can then pick which method they would prefer to use to capture the image.
 
 #### BlackBerry 10 Quirks
 
@@ -469,6 +474,8 @@ Tizen only supports a `destinationType` of
 - Ignores the `correctOrientation` parameter.
 
 - Ignores the `cameraDirection` parameter.
+
+- Ignores the `showLibraryButton` parameter.
 
 #### Firefox OS Quirks
 
@@ -490,17 +497,23 @@ Tizen only supports a `destinationType` of
 
 - Ignores the `cameraDirection` parameter.
 
+- Ignores the `showLibraryButton` parameter.
+
 #### iOS Quirks
 
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
 
 - When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
 
+- `showLibraryButton` adds a `Library` button to the default camera controls. For iPhone, this is on the lower right. For iPad, this is halfway between the shutter and `Cancel` buttons. The button is shown as the text `Library`, unless the app has access to the photo library already, in which case a thumbnail of the most recent image is provided. This is only supported on iOS 7+.
+
 #### Tizen Quirks
 
 - options not supported
 
 - always returns a FILE URI
+
+- Ignores the `showLibraryButton` parameter.
 
 #### Windows Phone 7 and 8 Quirks
 
@@ -514,3 +527,5 @@ Tizen only supports a `destinationType` of
 You may also comment or up-vote the related issue in the [issue tracker](https://issues.apache.org/jira/browse/CB-2083)
 
 - Ignores the `mediaType` property of `cameraOptions` as the Windows Phone SDK does not provide a way to choose videos from PHOTOLIBRARY.
+
+- `showLibraryButton` launches directly into the photo chooser task, and provides a camera button at the bottom to allow the user to toggle over into the camera.

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -125,6 +125,8 @@ Tizen only supports a `destinationType` of
 
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
 
+- Ignores the `showLibraryButton` parameter.
+
 #### Android Quirks
 
 - Any `cameraDirection` value results in a back-facing photo.
@@ -134,6 +136,8 @@ Tizen only supports a `destinationType` of
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
 
 - Ignores the `encodingType` parameter if the image is unedited (i.e. `quality` is 100, `correctOrientation` is false, and no `targetHeight` or `targetWidth` are specified). The `CAMERA` source will always return the JPEG file given by the native camera and the `PHOTOLIBRARY` and `SAVEDPHOTOALBUM` sources will return the selected file in its existing encoding.
+
+- When `showLibraryButton` is `true`, an Intent chooser is displayed which lists all possible handlers for either the Camera or File chooser -- and the user can then pick which method they would prefer to use to capture the image.
 
 #### BlackBerry 10 Quirks
 
@@ -146,6 +150,8 @@ Tizen only supports a `destinationType` of
 - Ignores the `correctOrientation` parameter.
 
 - Ignores the `cameraDirection` parameter.
+
+- Ignores the `showLibraryButton` parameter.
 
 #### Firefox OS Quirks
 
@@ -167,17 +173,23 @@ Tizen only supports a `destinationType` of
 
 - Ignores the `cameraDirection` parameter.
 
+- Ignores the `showLibraryButton` parameter.
+
 #### iOS Quirks
 
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
 
 - When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
 
+- `showLibraryButton` adds a `Library` button to the default camera controls. For iPhone, this is on the lower right. For iPad, this is halfway between the shutter and `Cancel` buttons. The button is shown as the text `Library`, unless the app has access to the photo library already, in which case a thumbnail of the most recent image is provided. This is only supported on iOS 7+.
+
 #### Tizen Quirks
 
 - options not supported
 
 - always returns a FILE URI
+
+- Ignores the `showLibraryButton` parameter.
 
 #### Windows Phone 7 and 8 Quirks
 
@@ -191,3 +203,5 @@ Tizen only supports a `destinationType` of
 You may also comment or up-vote the related issue in the [issue tracker](https://issues.apache.org/jira/browse/CB-2083)
 
 - Ignores the `mediaType` property of `cameraOptions` as the Windows Phone SDK does not provide a way to choose videos from PHOTOLIBRARY.
+
+- `showLibraryButton` launches directly into the photo chooser task, and provides a camera button at the bottom to allow the user to toggle over into the camera.

--- a/plugin.xml
+++ b/plugin.xml
@@ -77,6 +77,12 @@
             <clobbers target="CameraPopoverHandle" />
         </js-module>
 
+        <config-file target="res/values/strings.xml" parent="/resources">
+            <string name="plugin_camera_source_chooser">"Select Source"</string>
+            <string name="plugin_camera_get_picture">Get Picture</string>
+            <string name="plugin_camera_get_video">Get Video</string>
+            <string name="plugin_camera_get_all">Get All</string>
+        </config-file>
      </platform>
 
     <!-- amazon-fireos -->

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -60,6 +60,8 @@ typedef NSUInteger CDVMediaType;
 @property (assign) BOOL usesGeolocation;
 @property (assign) BOOL cropToSize;
 
+@property (assign) BOOL showLibraryButton;
+
 + (instancetype) createFromTakePictureArguments:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -85,6 +85,9 @@ static NSString* toBase64(NSData* data) {
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;
     
+    // Only if source is Camera && opt set
+    pictureOptions.showLibraryButton = (pictureOptions.sourceType == UIImagePickerControllerSourceTypeCamera) &&
+        [[command argumentAtIndex:12 withDefault:@(NO)] boolValue];
     return pictureOptions;
 }
 
@@ -365,7 +368,7 @@ static NSString* toBase64(NSData* data) {
                         self.metadata = [[NSMutableDictionary alloc] init];
                         
                         NSMutableDictionary* EXIFDictionary = [[controllerMetadata objectForKey:(NSString*)kCGImagePropertyExifDictionary]mutableCopy];
-                        if (EXIFDictionary)	{
+                        if (EXIFDictionary) {
                             [self.metadata setObject:EXIFDictionary forKey:(NSString*)kCGImagePropertyExifDictionary];
                         }
                         
@@ -575,15 +578,15 @@ static NSString* toBase64(NSData* data) {
 
 - (CLLocationManager*)locationManager
 {
-	if (locationManager != nil) {
-		return locationManager;
-	}
+    if (locationManager != nil) {
+        return locationManager;
+    }
     
-	locationManager = [[CLLocationManager alloc] init];
-	[locationManager setDesiredAccuracy:kCLLocationAccuracyNearestTenMeters];
-	[locationManager setDelegate:self];
+    locationManager = [[CLLocationManager alloc] init];
+    [locationManager setDesiredAccuracy:kCLLocationAccuracyNearestTenMeters];
+    [locationManager setDelegate:self];
     
-	return locationManager;
+    return locationManager;
 }
 
 - (void)locationManager:(CLLocationManager*)manager didUpdateToLocation:(CLLocation*)newLocation fromLocation:(CLLocation*)oldLocation
@@ -734,7 +737,205 @@ static NSString* toBase64(NSData* data) {
         [self performSelector:sel withObject:nil afterDelay:0];
     }
     
+    if (self.pictureOptions.showLibraryButton) {
+        // Register for notifications when the user captures an image
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleNotification:) name:@"_UIImagePickerControllerUserDidCaptureItem"
+                                                   object:nil];
+        
+        // Register for notifications when the user returns to the camera view to take another picture
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleNotification:)
+                                                     name:@"_UIImagePickerControllerUserDidRejectItem"
+                                                   object:nil];
+    }
+   
     [super viewWillAppear:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    if (self.pictureOptions.showLibraryButton) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self];
+    }
+    
+    [super viewDidDisappear:animated];
+}
+
+- (void)handleNotification:(NSNotification*)notification {
+    if ([[notification name] isEqualToString:@"_UIImagePickerControllerUserDidCaptureItem"]) {
+        // Remove overlay, so that it is not available on the preview view;
+        [self.cameraOverlayView setHidden:YES];
+    }
+    else if ([[notification name] isEqualToString:@"_UIImagePickerControllerUserDidRejectItem"]) {
+        // Retake button pressed on preview. Add overlay, so that is available on the camera again
+        [self.cameraOverlayView setHidden:NO];
+    }
+}
+
+// Create an overlay view that include a button allowing quick access to choose an image from the library
+- (UIView*)createOverlayView {
+    UIView* overlay = [[UIView alloc] initWithFrame:self.view.bounds];
+    
+    // Make the background transparent so the existing UI shows through
+    overlay.opaque = NO;
+    overlay.backgroundColor = [UIColor clearColor];
+    
+    // Make sure the view auto-resizes when the orientation changes
+    overlay.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    
+    // Add a button to allow access to the camera roll
+    UIButton *libraryButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    libraryButton.backgroundColor = [UIColor clearColor];
+    
+    // For now, set the title to (localized) "Library" so it appears even if we can't get the most recent picture
+    [libraryButton setTitle:NSLocalizedString(@"Library", nil) forState:UIControlStateNormal];
+    libraryButton.imageView.contentMode = UIViewContentModeScaleAspectFill;
+    
+    [libraryButton addTarget:self
+                      action:@selector(switchToCameraRoll)
+            forControlEvents:UIControlEventTouchUpInside];
+    
+    [libraryButton setTranslatesAutoresizingMaskIntoConstraints:NO];
+
+    // Set the image to the most recent one in the Camera Roll
+    [self setImageFromCameraRoll:libraryButton];
+    
+    // Add the button to the overlay
+    [overlay addSubview:libraryButton];
+    
+    int rightOffset = 0;
+    NSLayoutConstraint *bottomConstraint;
+    
+    // Positioning for iPad
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        rightOffset = -21;
+        bottomConstraint = [NSLayoutConstraint constraintWithItem:libraryButton
+                                                        attribute:NSLayoutAttributeCenterY
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:overlay
+                                                        attribute:NSLayoutAttributeCenterY
+                                                       multiplier:1.5
+                                                         constant:0];
+    }
+    // Positioning for iPhone
+    else {
+        UIScreen* mainScreen = [UIScreen mainScreen];
+        CGFloat mainScreenHeight = mainScreen.bounds.size.height;
+        CGFloat mainScreenWidth = mainScreen.bounds.size.width;
+        
+        // On screens >480px tall, the controls are bigger
+        int limit = MAX(mainScreenHeight,mainScreenWidth);
+        int bottomOffset;
+        
+        // Determine the bottom offset based on the device screen size
+        switch (limit) {
+            case 480:
+            case 568:
+                bottomOffset = -7;
+                break;
+                
+            case 667:
+                bottomOffset = -18;
+                break;
+
+            case 736:
+            default:
+                bottomOffset = -27;
+                break;
+        
+        }
+
+        rightOffset = -13;
+        bottomConstraint = [NSLayoutConstraint constraintWithItem:libraryButton
+                                                        attribute:NSLayoutAttributeBottom
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:overlay
+                                                        attribute:NSLayoutAttributeBottom
+                                                       multiplier:1
+                                                         constant:bottomOffset];
+    }
+    
+    // Add auto-layout constraints to keep the size and position of the button correct on all devices
+    [overlay addConstraints:@[
+                              [NSLayoutConstraint constraintWithItem:libraryButton
+                                                           attribute:NSLayoutAttributeWidth
+                                                           relatedBy:NSLayoutRelationEqual
+                                                              toItem:nil
+                                                           attribute:NSLayoutAttributeNotAnAttribute
+                                                          multiplier:1.0
+                                                            constant:60.0],
+                              
+                              [NSLayoutConstraint constraintWithItem:libraryButton
+                                                           attribute:NSLayoutAttributeHeight
+                                                           relatedBy:NSLayoutRelationEqual
+                                                              toItem:nil
+                                                           attribute:NSLayoutAttributeNotAnAttribute
+                                                          multiplier:1.0
+                                                            constant:60.0],
+                              
+                              [NSLayoutConstraint constraintWithItem:libraryButton
+                                                           attribute:NSLayoutAttributeRight
+                                                           relatedBy:NSLayoutRelationEqual
+                                                              toItem:overlay
+                                                           attribute:NSLayoutAttributeRight
+                                                          multiplier:1
+                                                            constant:rightOffset],
+                              bottomConstraint
+                              ]];
+    
+    return overlay;
+}
+
+// Retrieves the last image from the camera roll, and sets it as the image for the library button
+- (void)setImageFromCameraRoll:(UIButton*)button {
+    // Make sure we have authorization to access it first, to avoid putting up an extra prompt right away
+    ALAuthorizationStatus status = [ALAssetsLibrary authorizationStatus];
+    
+    if (status != ALAuthorizationStatusAuthorized) {
+        return;
+    }
+    
+    // Enumerate the assets, take the first image, and set it on the UIButton
+    ALAssetsGroupEnumerationResultsBlock assetEnumBlock = ^(ALAsset *asset, NSUInteger index, BOOL *stop) {
+        if (!asset) return;
+        
+        ALAssetRepresentation *repr = [asset defaultRepresentation];
+        UIImage *img = [UIImage imageWithCGImage:[repr fullScreenImage]];
+        [button setImage:img forState:UIControlStateNormal];
+            
+        // Call this on the UI thread so it updates immediately
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [button setNeedsLayout];
+        });
+            
+        *stop = YES;
+    };
+
+    ALAssetsLibraryGroupsEnumerationResultsBlock groupsEnumBlock = ^(ALAssetsGroup *group, BOOL *stop) {
+        if (nil != group) {
+            // Filter the group to only include photos
+            [group setAssetsFilter:[ALAssetsFilter allPhotos]];
+            
+            // Enumerate assets in reverse to get most recent
+            [group enumerateAssetsWithOptions:NSEnumerationReverse
+                                   usingBlock:assetEnumBlock];
+        }
+        
+        *stop = NO;
+    };
+    
+    // Enumerate the assets library
+    ALAssetsLibrary *assetsLibrary = [[ALAssetsLibrary alloc] init];
+    [assetsLibrary enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos
+                                 usingBlock:groupsEnumBlock
+                               failureBlock:^(NSError *error) {
+                                   NSLog(@"Camera: error enumerating library [%@]", error);
+                               }];
+}
+
+- (void)switchToCameraRoll {
+    // Switch the UIImagePickerController to show the saved photos album
+    self.sourceType = UIImagePickerControllerSourceTypeSavedPhotosAlbum;
 }
 
 + (instancetype) createFromPictureOptions:(CDVPictureOptions*)pictureOptions;
@@ -749,6 +950,12 @@ static NSString* toBase64(NSData* data) {
         cameraPicker.mediaTypes = @[(NSString*)kUTTypeImage];
         // We can only set the camera device if we're actually using the camera.
         cameraPicker.cameraDevice = pictureOptions.cameraDirection;
+        
+        // If enabled, show button to allow accessing library instead
+        // For iOS 7+ only, as the UI for lower versions is different
+        if (pictureOptions.showLibraryButton == YES && IsAtLeastiOSVersion(@"7.0")) {
+            cameraPicker.cameraOverlayView = [cameraPicker createOverlayView];
+        }
     } else if (pictureOptions.mediaType == MediaTypeAll) {
         cameraPicker.mediaTypes = [UIImagePickerController availableMediaTypesForSourceType:cameraPicker.sourceType];
     } else {

--- a/src/wp/Camera.cs
+++ b/src/wp/Camera.cs
@@ -124,13 +124,13 @@ namespace WPCordovaClassLib.Cordova.Commands
             [DataMember(IsRequired = false, Name = "allowEdit")]
             public bool AllowEdit { get; set; }
 
-                        /// <summary>
+            /// <summary>
             /// Height in pixels to scale image
             /// </summary>
             [DataMember(IsRequired = false, Name = "encodingType")]
             public int EncodingType { get; set; }
 
-                        /// <summary>
+            /// <summary>
             /// Height in pixels to scale image
             /// </summary>
             [DataMember(IsRequired = false, Name = "mediaType")]
@@ -143,12 +143,17 @@ namespace WPCordovaClassLib.Cordova.Commands
             [DataMember(IsRequired = false, Name = "targetHeight")]
             public int TargetHeight { get; set; }
 
-
             /// <summary>
             /// Width in pixels to scale image
             /// </summary>
             [DataMember(IsRequired = false, Name = "targetWidth")]
             public int TargetWidth { get; set; }
+
+            /// <summary>
+            /// Whether to allow moving between camera and library
+            /// </summary>
+            [DataMember(IsRequired = false, Name = "showLibraryButton")]
+            public bool ShowLibraryButton { get; set; }
 
             /// <summary>
             /// Creates options object with default parameters
@@ -174,6 +179,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 SaveToPhotoAlbum = false;
                 CorrectOrientation = true;
                 AllowEdit = false;
+                ShowLibraryButton = false;
                 MediaType = -1;
                 EncodingType = -1;
             }
@@ -190,7 +196,8 @@ namespace WPCordovaClassLib.Cordova.Commands
             {
                 string[] args = JSON.JsonHelper.Deserialize<string[]>(options);
                 // ["quality", "destinationType", "sourceType", "targetWidth", "targetHeight", "encodingType",
-                //     "mediaType", "allowEdit", "correctOrientation", "saveToPhotoAlbum" ]
+                //     "mediaType", "allowEdit", "correctOrientation", "saveToPhotoAlbum", "popoverOptions",
+                //     "cameraDirection", "showLibraryButton"]
                 cameraOptions = new CameraOptions();
                 cameraOptions.Quality = int.Parse(args[0]);
                 cameraOptions.DestinationType = int.Parse(args[1]);
@@ -202,6 +209,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 cameraOptions.AllowEdit = bool.Parse(args[7]);
                 cameraOptions.CorrectOrientation = bool.Parse(args[8]);
                 cameraOptions.SaveToPhotoAlbum = bool.Parse(args[9]);
+                cameraOptions.ShowLibraryButton = bool.Parse(args[12]);
 
                 // a very large number will force the other value to be the bound
                 if (cameraOptions.TargetWidth > -1 && cameraOptions.TargetHeight == -1)
@@ -235,7 +243,19 @@ namespace WPCordovaClassLib.Cordova.Commands
             ChooserBase<PhotoResult> chooserTask = null;
             if (cameraOptions.PictureSourceType == CAMERA)
             {
-                chooserTask = new CameraCaptureTask();
+                // If the user requested to show the library button, then we will
+                // show the photo chooser with a camera button, as that's the closest
+                // we can get with the current WP Tasks.
+                if (cameraOptions.ShowLibraryButton)
+                {
+                    PhotoChooserTask task = new PhotoChooserTask();
+                    task.ShowCamera = true;
+                    chooserTask = task;
+                }
+                else
+                {
+                    chooserTask = new CameraCaptureTask();
+                }
             }
             else if ((cameraOptions.PictureSourceType == PHOTOLIBRARY) || (cameraOptions.PictureSourceType == SAVEDPHOTOALBUM))
             {

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -75,6 +75,7 @@ for (var key in Camera) {
  * @property {Boolean} [saveToPhotoAlbum] - Save the image to the photo album on the device after capture.
  * @property {module:CameraPopoverOptions} [popoverOptions] - iOS-only options that specify popover location in iPad.
  * @property {module:Camera.Direction} [cameraDirection=BACK] - Choose the camera to use (front- or back-facing).
+ * @property {Boolean} [showLibraryButton] - Shows an option to choose an image from their photo library in addition to the camera. Only works when `PictureSourceType` is `CAMERA`.
  */
 
 /**
@@ -147,9 +148,10 @@ cameraExport.getPicture = function(successCallback, errorCallback, options) {
     var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     var popoverOptions = getValue(options.popoverOptions, null);
     var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    var showLibraryButton = !!options.showLibraryButton;
 
     var args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
-                mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
+                mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection, showLibraryButton];
 
     exec(successCallback, errorCallback, "Camera", "takePicture", args);
     // XXX: commented out


### PR DESCRIPTION
A new camera option, `showLibraryButton`, is added which allows the user
to easily switch from the camera to the photo library once they have
entered the plugin.

Currently, this is optimally supported on iOS (7+), with additional
implementations for Android and WP8 based on what was available for
those platforms. Please see the documentation updates (specifically, the 'Quirks' changes) for details on how this is implemented on each platform.

I realize that the behavior on Android and Windows Phone is not 100% consistent to iOS, but it is the best that can be done given the constraints of what's available on those platforms. If we were to rewrite this plugin to use completely custom camera UIs, we could do a whole lot better -- but that's a much bigger undertaking.

I also made some opportunistic changes while I was working on this, including cleaning up parameter initialization for Android, moving hardcoded strings to localizable ones, fixing some space/tab and indentation inconsistencies, and other code cleanup.

All modifications here do not impact the default functionality of someone who is currently using this plugin (though it would be great for additional test coverage on that). In order for this change to work, `showLibraryButton: true` must be passed in the options, and the source type must be `CAMERA`.

@infil00p @shazron @nikhilkh @stevengill Is it possible to get reviews for your respective platforms?

Fixes https://issues.apache.org/jira/browse/CB-9193