### PR TITLE
CB-6190 - iOS camera plugin ignores quality parameter

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -346,7 +346,7 @@ static NSString* toBase64(NSData* data) {
             break;
         case EncodingTypeJPEG:
         {
-            if ((options.allowsEditing == NO) && (options.targetSize.width <= 0) && (options.targetSize.height <= 0) && (options.correctOrientation == NO)){
+            if ((options.allowsEditing == NO) && (options.targetSize.width <= 0) && (options.targetSize.height <= 0) && (options.correctOrientation == NO) && (([options.quality integerValue] == 100) || (options.sourceType != UIImagePickerControllerSourceTypeCamera))){
                 // use image unedited as requested , don't resize
                 data = UIImageJPEGRepresentation(image, 1.0);
             } else {


### PR DESCRIPTION
CB-6190 - iOS camera plugin ignores quality parameter in some
circunstances
Added a check to not downscale if quality is 100 or sourceType !=
UIImagePickerControllerSourceTypeCamera (according to the docs, images
from gallery aren’t downscaled)