### PR TITLE
CB-9443 Pick correct maxResolution

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -696,21 +696,22 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     // decide which max pixels should be supported by targetWidth or targetHeight.
     var maxRes = null;
     var UIMaxRes = WMCapture.CameraCaptureUIMaxPhotoResolution;
+    var totalPixels = targetWidth * targetHeight;
     switch (true) {
-        case (targetWidth >= 1280 || targetHeight >= 960) :
-            cameraCaptureUI.photoSettings.maxResolution = UIMaxRes.large3M;
+        case (totalPixels <= 320 * 240):
+            cameraCaptureUI.photoSettings.maxResolution = UIMaxRes.verySmallQvga;
             break;
-        case (targetWidth >= 1024 || targetHeight >= 768) :
-            maxRes = UIMaxRes.mediumXga;
-            break;
-        case    (targetWidth >= 800 || targetHeight >= 600) :
-            maxRes = UIMaxRes.mediumXga;
-            break;
-        case  (targetWidth >= 640 || targetHeight >= 480) :
+        case (totalPixels <= 640 * 480):
             maxRes = UIMaxRes.smallVga;
             break;
-        case    (targetWidth >= 320 || targetHeight >= 240) :
-            maxRes = UIMaxRes.verySmallQvga;
+        case (totalPixels <= 1024 * 768):
+            maxRes = UIMaxRes.mediumXga;
+            break;
+        case (totalPixels <= 3 * 1000 * 1000):
+            maxRes = UIMaxRes.large3M;
+            break;
+        case (totalPixels <= 5 * 1000 * 1000):
+            maxRes = UIMaxRes.veryLarge5M;
             break;
         default :
             maxRes = UIMaxRes.highestAvailable;

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -697,24 +697,19 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     var maxRes = null;
     var UIMaxRes = WMCapture.CameraCaptureUIMaxPhotoResolution;
     var totalPixels = targetWidth * targetHeight;
-    switch (true) {
-        case (totalPixels <= 320 * 240):
-            cameraCaptureUI.photoSettings.maxResolution = UIMaxRes.verySmallQvga;
-            break;
-        case (totalPixels <= 640 * 480):
-            maxRes = UIMaxRes.smallVga;
-            break;
-        case (totalPixels <= 1024 * 768):
-            maxRes = UIMaxRes.mediumXga;
-            break;
-        case (totalPixels <= 3 * 1000 * 1000):
-            maxRes = UIMaxRes.large3M;
-            break;
-        case (totalPixels <= 5 * 1000 * 1000):
-            maxRes = UIMaxRes.veryLarge5M;
-            break;
-        default :
-            maxRes = UIMaxRes.highestAvailable;
+
+    if (totalPixels <= 320 * 240) {
+        maxRes = UIMaxRes.verySmallQvga;
+    } else if (totalPixels <= 640 * 480) {
+        maxRes = UIMaxRes.smallVga;
+    } else if (totalPixels <= 1024 * 768) {
+        maxRes = UIMaxRes.mediumXga;
+    } else if (totalPixels <= 3 * 1000 * 1000) {
+        maxRes = UIMaxRes.large3M;
+    } else if (totalPixels <= 5 * 1000 * 1000) {
+        maxRes = UIMaxRes.veryLarge5M;
+    } else {
+        maxRes = UIMaxRes.highestAvailable;
     }
 
     cameraCaptureUI.photoSettings.maxResolution = maxRes;

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -698,18 +698,25 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     var UIMaxRes = WMCapture.CameraCaptureUIMaxPhotoResolution;
     var totalPixels = targetWidth * targetHeight;
 
-    if (totalPixels <= 320 * 240) {
-        maxRes = UIMaxRes.verySmallQvga;
-    } else if (totalPixels <= 640 * 480) {
-        maxRes = UIMaxRes.smallVga;
-    } else if (totalPixels <= 1024 * 768) {
-        maxRes = UIMaxRes.mediumXga;
-    } else if (totalPixels <= 3 * 1000 * 1000) {
-        maxRes = UIMaxRes.large3M;
-    } else if (totalPixels <= 5 * 1000 * 1000) {
-        maxRes = UIMaxRes.veryLarge5M;
-    } else {
-        maxRes = UIMaxRes.highestAvailable;
+    switch (true) {
+        case (totalPixels <= 320 * 240):
+            maxRes = UIMaxRes.verySmallQvga;
+            break;
+        case (totalPixels <= 640 * 480):
+            maxRes = UIMaxRes.smallVga;
+            break;
+        case (totalPixels <= 1024 * 768):
+            maxRes = UIMaxRes.mediumXga;
+            break;
+        case (totalPixels <= 3 * 1000 * 1000):
+            maxRes = UIMaxRes.large3M;
+            break;
+        case (totalPixels <= 5 * 1000 * 1000):
+            maxRes = UIMaxRes.veryLarge5M;
+            break;
+        default:
+            maxRes = UIMaxRes.highestAvailable;
+            break;
     }
 
     cameraCaptureUI.photoSettings.maxResolution = maxRes;


### PR DESCRIPTION
According to MSDN docs we're currently not picking the correct maxResolution for images:
https://msdn.microsoft.com/en-us/library/windows/apps/windows.media.capture.cameracaptureuimaxphotoresolution.aspx