### PR TITLE
Retaining image ratio when resizing

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -93,9 +93,9 @@ function resizeImage(successCallback, errorCallback, file, targetWidth, targetHe
             var image = new Image();
             image.src = imageData;
             image.onload = function() {
-                var scale = Math.min(targetWidth, targetHeight) / Math.max(this.width, this.height);
-                var imageWidth = scale * this.width;
-                var imageHeight = scale * this.height;
+                var ratio = Math.min(targetWidth / this.width, targetHeight / this.height);
+                var imageWidth = ratio * this.width;
+                var imageHeight = ratio * this.height;
 
                 var canvas = document.createElement('canvas');
                 var storageFileName;
@@ -136,9 +136,9 @@ function resizeImageBase64(successCallback, errorCallback, file, targetWidth, ta
         image.src = imageData;
 
         image.onload = function() {
-            var scale = Math.min(targetWidth, targetHeight) / Math.max(this.width, this.height);
-            var imageWidth = scale * this.width;
-            var imageHeight = scale * this.height;
+            var ratio = Math.min(targetWidth / this.width, targetHeight / this.height);
+            var imageWidth = ratio * this.width;
+            var imageHeight = ratio * this.height;
             var canvas = document.createElement('canvas');
 
             canvas.width = imageWidth;

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -93,8 +93,10 @@ function resizeImage(successCallback, errorCallback, file, targetWidth, targetHe
             var image = new Image();
             image.src = imageData;
             image.onload = function() {
-                var imageWidth = targetWidth,
-                    imageHeight = targetHeight;
+                var scale = Math.min(targetWidth, targetHeight) / Math.max(this.width, this.height);
+                var imageWidth = scale * this.width;
+                var imageHeight = scale * this.height;
+
                 var canvas = document.createElement('canvas');
                 var storageFileName;
 
@@ -134,8 +136,9 @@ function resizeImageBase64(successCallback, errorCallback, file, targetWidth, ta
         image.src = imageData;
 
         image.onload = function() {
-            var imageWidth = targetWidth,
-                imageHeight = targetHeight;
+            var scale = Math.min(targetWidth, targetHeight) / Math.max(this.width, this.height);
+            var imageWidth = scale * this.width;
+            var imageHeight = scale * this.height;
             var canvas = document.createElement('canvas');
 
             canvas.width = imageWidth;


### PR DESCRIPTION
According to documentation and iOS/Android behavior, resized images should retain ratio. This code fixes windows scaling.