### PR TITLE
CB-9633 iOS Taking a Picture With Option destinationType:NATIVE_URI not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ with the Google Plus Photos application.  Other crops may not work.
 
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
 
+- When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
+
 #### Tizen Quirks
 
 - options not supported


### PR DESCRIPTION
In case sourceType == Camera we receive nil as Uri because image is stored in memory. This PR adds logic to save image locally before obtaining resultant uri in this case