### PR TITLE
CB-9960 android: Fixed FileNotFoundException for some gallery images

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -547,7 +547,7 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         String realPath = FileHelper.getRealPath(uri, this.cordova);
 
         // Get filename from uri
-        String fileName = realPath != null ?
+        String fileName = realPath != null && !realPath.isEmpty() ?
             realPath.substring(realPath.lastIndexOf('/') + 1) :
             "modified." + (this.encodingType == JPEG ? "jpg" : "png");
 
@@ -561,7 +561,7 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         bitmap.compress(compressFormat, this.mQuality, os);
         os.close();
 
-        if (realPath != null && this.encodingType == JPEG) {
+        if (realPath != null && !realPath.isEmpty() && this.encodingType == JPEG) {
             // Create an ExifHelper to save the exif data that is lost during compression
             ExifHelper exif = new ExifHelper();
 


### PR DESCRIPTION
Certain gallery applications (such as Google Photos) return `content://` URIs that our method of getting a file path (`FileHelper.getRealPath()`) fails to properly dereference. Using these applications with `cameraOptions` that cause the image to be edited (width/height, correctOrientation, allowEdit, etc.) would trigger a FileNotFoundException and cause the plugin to fail because it is unable to grab the original filename. This checks the result of `FileHelper.getRealPath()` and if it fails to grab a path instead uses the generic filename "modified.jpg" for the local file (which was the intended behavior before, we were just checking the result of `getRealPath()` incorrectly). Note: These images will lose their EXIF data (the Exifinterface needs a local file path, I think)