### PR TITLE
CB-9169 android: Fixed filetype for uncompressed images and added quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Can only return photos as base64-encoded image.
 
 #### Firefox OS Quirks
 
-Camera plugin is currently implemented using [Web Activities](https://hacks.mozilla.org/2013/01/introducing-web-activities/). 
+Camera plugin is currently implemented using [Web Activities](https://hacks.mozilla.org/2013/01/introducing-web-activities/).
 
 #### iOS Quirks
 
@@ -450,6 +450,8 @@ Tizen only supports a `destinationType` of
 - **`allowEdit` is unpredictable on Android and it should not be used!** The Android implementation of this plugin tries to find and use an application on the user's device to do image cropping. The plugin has no control over what application the user selects to perform the image cropping and it is very possible that the user could choose an incompatible option and cause the plugin to fail. This sometimes works because most devices come with an application that handles cropping in a way that is compatible with this plugin (Google Plus Photos), but it is unwise to rely on that being the case. If image editing is essential to your application, consider seeking a third party library or plugin that provides its own image editing utility for a more robust solution.
 
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
+
+- Ignores the `encodingType` parameter if the image is unedited (i.e. `quality` is 100, `correctOrientation` is false, and no `targetHeight` or `targetWidth` are specified). The `CAMERA` source will always return the JPEG file given by the native camera and the `PHOTOLIBRARY` and `SAVEDPHOTOALBUM` sources will return the selected file in its existing encoding.
 
 #### BlackBerry 10 Quirks
 

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -85,7 +85,7 @@ Can only return photos as base64-encoded image.
 
 #### Firefox OS Quirks
 
-Camera plugin is currently implemented using [Web Activities](https://hacks.mozilla.org/2013/01/introducing-web-activities/). 
+Camera plugin is currently implemented using [Web Activities](https://hacks.mozilla.org/2013/01/introducing-web-activities/).
 
 #### iOS Quirks
 
@@ -127,6 +127,8 @@ Tizen only supports a `destinationType` of
 - **`allowEdit` is unpredictable on Android and it should not be used!** The Android implementation of this plugin tries to find and use an application on the user's device to do image cropping. The plugin has no control over what application the user selects to perform the image cropping and it is very possible that the user could choose an incompatible option and cause the plugin to fail. This sometimes works because most devices come with an application that handles cropping in a way that is compatible with this plugin (Google Plus Photos), but it is unwise to rely on that being the case. If image editing is essential to your application, consider seeking a third party library or plugin that provides its own image editing utility for a more robust solution.
 
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
+
+- Ignores the `encodingType` parameter if the image is unedited (i.e. `quality` is 100, `correctOrientation` is false, and no `targetHeight` or `targetWidth` are specified). The `CAMERA` source will always return the JPEG file given by the native camera and the `PHOTOLIBRARY` and `SAVEDPHOTOALBUM` sources will return the selected file in its existing encoding.
 
 #### BlackBerry 10 Quirks
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -162,6 +162,13 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 this.targetHeight = -1;
             }
 
+            // We don't return full-quality PNG files. The camera outputs a JPEG
+            // so requesting it as a PNG provides no actual benefit
+            if (this.targetHeight == -1 && this.targetWidth == -1 && this.mQuality == 100 &&
+                    !this.correctOrientation && this.encodingType == PNG && this.srcType == CAMERA) {
+                this.encodingType = JPEG;
+            }
+
              try {
                 if (this.srcType == CAMERA) {
                     this.callTakePicture(destType, encodingType);


### PR DESCRIPTION
When trying to get uncompressed images on Android using camera options like these:
``` javascript
{
    destinationType : Camera.DestinationType.FILE_URL,
    sourceType : Camera.PictureSourceType.CAMERA,
    encodingType: Camera.EncodingType.PNG,
    quality: 100,
    saveToPhotoAlbum: true
}
```
the plugin will return a JPEG file with a .png filename. This pull request fixes the filename and documents the Android quirk that `encodingType` is ignored by the plugin on Android for uncompressed files. It currently does not make sense to actually provide PNG support in this case, because native camera apps return JPEG files and so converting to PNG does not improve quality, it just hurts performance. Same can be said for the gallery which just returns the selected file.