### PR TITLE
[CB-10093][android] fix failure to get image from gallery, caused by the uri passed into outputModifiedBitmap() is not a document URI

### DIFF
--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -79,30 +79,59 @@ public class FileHelper {
     @SuppressLint("NewApi")
     public static String getRealPathFromURI_API19(Context context, Uri uri) {
         String filePath = "";
-        try {
-            String wholeID = DocumentsContract.getDocumentId(uri);
 
-            // Split at colon, use second item in the array
-            String id = wholeID.indexOf(":") > -1 ? wholeID.split(":")[1] : wholeID.indexOf(";") > -1 ? wholeID
-                    .split(";")[1] : wholeID;
+        try {
+            String id;
+
+            if (DocumentsContract.isDocumentUri(context, uri)) {
+                String wholeID = DocumentsContract.getDocumentId(uri);
+
+                // Split at colon, use second item in the array
+                id = wholeID.indexOf(":") > -1
+                        ? wholeID.split(":")[1]
+                        : wholeID.indexOf(";") > -1
+                        ? wholeID.split(";")[1]
+                        : wholeID;
+            } else {
+                final String uriStr = uri.toString();
+
+                if (
+                        uriStr.startsWith(
+                                MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString()
+                        )
+                ) {
+                    id = uriStr.substring(uriStr.lastIndexOf("/") + 1);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Cannot get real path from uri: " + uriStr
+                    );
+                }
+            }
 
             String[] column = { MediaStore.Images.Media.DATA };
 
             // where id is equal to
             String sel = MediaStore.Images.Media._ID + "=?";
 
-            Cursor cursor = context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, column,
-                    sel, new String[] { id }, null);
+            Cursor cursor = context.getContentResolver().query(
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                    column,
+                    sel,
+                    new String[] { id },
+                    null
+            );
 
             int columnIndex = cursor.getColumnIndex(column[0]);
 
             if (cursor.moveToFirst()) {
                 filePath = cursor.getString(columnIndex);
             }
+
             cursor.close();
         } catch (Exception e) {
             filePath = "";
         }
+
         return filePath;
     }
 
@@ -209,7 +238,7 @@ public class FileHelper {
         }
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
     }
-    
+
     /**
      * Returns the mime type of the data specified by the given URI string.
      *

--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -25,6 +25,7 @@ import android.os.Build;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.webkit.MimeTypeMap;
+import android.webkit.URLUtil;
 
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.LOG;
@@ -32,7 +33,9 @@ import org.apache.cordova.LOG;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLDecoder;
 import java.util.Locale;
+import java.util.Scanner;
 
 public class FileHelper {
     private static final String LOG_TAG = "FileUtils";
@@ -76,14 +79,31 @@ public class FileHelper {
         return FileHelper.getRealPath(Uri.parse(uriString), cordova);
     }
 
+    private static String extractDocumentIdFromExternalContentURI(String uri) {
+        final String externalContentURI = MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString();
+
+        return new Scanner(
+            uri.substring(
+                externalContentURI.indexOf(externalContentURI) + externalContentURI.length()
+            )
+        ).useDelimiter("[^0-9]+").next();
+    }
+
     @SuppressLint("NewApi")
     public static String getRealPathFromURI_API19(Context context, Uri uri) {
         String filePath = "";
 
         try {
-            String id;
+            String id = null;
+            String uriStr = uri.toString();
 
-            if (DocumentsContract.isDocumentUri(context, uri)) {
+            if (URLUtil.isFileUrl(uri.toString())) {
+                // case 1: the uri is already path to file system
+
+                return URLDecoder.decode(uriStr, "UTF-8");
+            } else if (DocumentsContract.isDocumentUri(context, uri)) {
+                // case 2: uri is the a documentUri
+
                 String wholeID = DocumentsContract.getDocumentId(uri);
 
                 // Split at colon, use second item in the array
@@ -92,16 +112,28 @@ public class FileHelper {
                         : wholeID.indexOf(";") > -1
                             ? wholeID.split(";")[1]
                             : wholeID;
-            } else {
-                final String uriStr = uri.toString();
+            } else if (uriStr.startsWith(MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString())) {
+                // case 3: uri is an external content uri
 
-                if (uriStr.startsWith(MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString())) {
-                    id = uriStr.substring(uriStr.lastIndexOf("/") + 1);
-                } else {
-                    throw new IllegalArgumentException(
-                        "Cannot get real path from uri: " + uriStr
-                    );
+                id = extractDocumentIdFromExternalContentURI(uriStr);
+            } else if (uriStr.lastIndexOf("content%3A%2F") > 0) {
+                uriStr = URLDecoder.decode(
+                    uriStr.substring(uriStr.lastIndexOf("content%3A%2F")),
+                    "UTF-8"
+                );
+
+                if (
+                    uriStr.startsWith(MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString())
+                ) {
+                    // case 4: uri has an embedded external content uri
+                    id = extractDocumentIdFromExternalContentURI(uriStr);
                 }
+            }
+
+            if (id == null) {
+                throw new IllegalArgumentException(
+                    "Cannot get real path from uri: " + uri
+                );
             }
 
             String[] column = { MediaStore.Images.Media.DATA };
@@ -109,8 +141,13 @@ public class FileHelper {
             // where id is equal to
             String sel = MediaStore.Images.Media._ID + "=?";
 
-            Cursor cursor = context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, column,
-                    sel, new String[] { id }, null);
+            Cursor cursor = context.getContentResolver().query(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                column,
+                sel,
+                new String[] { id },
+                null
+            );
 
             int columnIndex = cursor.getColumnIndex(column[0]);
 

--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -90,20 +90,16 @@ public class FileHelper {
                 id = wholeID.indexOf(":") > -1
                         ? wholeID.split(":")[1]
                         : wholeID.indexOf(";") > -1
-                        ? wholeID.split(";")[1]
-                        : wholeID;
+                            ? wholeID.split(";")[1]
+                            : wholeID;
             } else {
                 final String uriStr = uri.toString();
 
-                if (
-                        uriStr.startsWith(
-                                MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString()
-                        )
-                ) {
+                if (uriStr.startsWith(MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString())) {
                     id = uriStr.substring(uriStr.lastIndexOf("/") + 1);
                 } else {
                     throw new IllegalArgumentException(
-                            "Cannot get real path from uri: " + uriStr
+                        "Cannot get real path from uri: " + uriStr
                     );
                 }
             }
@@ -113,13 +109,8 @@ public class FileHelper {
             // where id is equal to
             String sel = MediaStore.Images.Media._ID + "=?";
 
-            Cursor cursor = context.getContentResolver().query(
-                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                    column,
-                    sel,
-                    new String[] { id },
-                    null
-            );
+            Cursor cursor = context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, column,
+                    sel, new String[] { id }, null);
 
             int columnIndex = cursor.getColumnIndex(column[0]);
 


### PR DESCRIPTION
fixing: https://issues.apache.org/jira/browse/CB-10093

files picked from the Gallery app is in the format of

```
content://media/external/images/media/117209
```

This would cause ```DocumentsContract.getDocumentId``` to throw exception. [See](http://grepcode.com/file/repo1.maven.org/maven2/org.robolectric/android-all/4.4_r1-robolectric-1/android/provider/DocumentsContract.java#619)

This patch fixes it.