### PR TITLE
Fix missing CAMERA permission for Android M

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -238,10 +238,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      */
     public void callTakePicture(int returnType, int encodingType) {
-        if (cordova.hasPermission(permissions[TAKE_PIC_SEC])) {
+        if (cordova.hasPermission(permissions[TAKE_PIC_SEC]) && cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC])) {
             takePicture(returnType, encodingType);
         } else {
-            getReadPermission(TAKE_PIC_SEC);
+            cordova.requestPermissions(this, TAKE_PIC_SEC, permissions);
         }
     }
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -105,7 +105,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private boolean orientationCorrected;   // Has the picture's orientation been corrected
     private boolean allowEdit;              // Should we allow the user to crop the image.
 
-    protected final static String[] permissions = { Manifest.permission.READ_EXTERNAL_STORAGE };
+    protected final static String[] permissions = { Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE };
 
     public CallbackContext callbackContext;
     private int numPics;
@@ -117,7 +117,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
     protected void getReadPermission(int requestCode)
     {
-        cordova.requestPermission(this, requestCode, Manifest.permission.READ_EXTERNAL_STORAGE);
+        cordova.requestPermission(this, requestCode, permissions[requestCode]);
     }
 
     /**
@@ -178,7 +178,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     // preserve the original exif data and filename in the modified file that is
                     // created
                     if(this.mediaType == PICTURE && (this.destType == FILE_URI || this.destType == NATIVE_URI)
-                            && fileWillBeModified() && !cordova.hasPermission(permissions[0])) {
+                            && fileWillBeModified() && !cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC])) {
                         getReadPermission(SAVE_TO_ALBUM_SEC);
                     } else {
                         this.getImage(this.srcType, destType, encodingType);
@@ -238,7 +238,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      */
     public void callTakePicture(int returnType, int encodingType) {
-        if (cordova.hasPermission(permissions[0])) {
+        if (cordova.hasPermission(permissions[TAKE_PIC_SEC])) {
             takePicture(returnType, encodingType);
         } else {
             getReadPermission(TAKE_PIC_SEC);

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -58,6 +58,9 @@ import android.provider.MediaStore;
 import android.util.Base64;
 import android.util.Log;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.PermissionInfo;
+
 /**
  * This class launches the camera view, allows the user to take a picture, closes the camera view,
  * and returns the captured image.  When the camera view is closed, the screen displayed before
@@ -238,13 +241,40 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      */
     public void callTakePicture(int returnType, int encodingType) {
-        if (cordova.hasPermission(permissions[TAKE_PIC_SEC]) && cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC])) {
+		boolean takePicturePermission = cordova.hasPermission(permissions[TAKE_PIC_SEC]);
+
+		if (!takePicturePermission) {
+			takePicturePermission = true; // This permission is not required, unless we find android.permission.CAMERA in the package
+			try {
+				PackageManager packageManager = this.cordova.getActivity().getPackageManager();
+				String[] permissionsInPackage = packageManager.getPackageInfo(this.cordova.getActivity().getPackageName(), PackageManager.GET_PERMISSIONS).requestedPermissions;
+				if (permissionsInPackage != null) {
+					for (String permission : permissionsInPackage) {
+						if (permission.equals(Manifest.permission.CAMERA)) {
+							takePicturePermission = false;
+							break;
+						}
+					}
+				}
+			} catch (NameNotFoundException e) {	} 			
+		}
+
+		boolean saveAlbumPermission = cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC]);
+        if (takePicturePermission && saveAlbumPermission) {
             takePicture(returnType, encodingType);
         } else {
-            cordova.requestPermissions(this, TAKE_PIC_SEC, permissions);
+			if (saveAlbumPermission && !takePicturePermission) {
+				cordova.requestPermission(this, TAKE_PIC_SEC, permissions[TAKE_PIC_SEC]);
+			}
+			else if (!saveAlbumPermission && takePicturePermission) {
+				cordova.requestPermission(this, TAKE_PIC_SEC, permissions[SAVE_TO_ALBUM_SEC]);
+			}
+			else
+			{
+				cordova.requestPermissions(this, TAKE_PIC_SEC, permissions);
+			}
         }
     }
-
 
     public void takePicture(int returnType, int encodingType)
     {


### PR DESCRIPTION
Fixing a bug where for Android M new permissions model, only external storage permission was asked, while camera permission was not, causing camera to fail on Android 6.0