### PR TITLE
[iOS] Fixed authorization error when user clicks cancel in image selector view.

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -518,7 +518,7 @@ static NSString* toBase64(NSData* data) {
     
     dispatch_block_t invoke = ^ (void) {
         CDVPluginResult* result;
-        if ([ALAssetsLibrary authorizationStatus] == ALAuthorizationStatusAuthorized) {
+        if (picker.sourceType == UIImagePickerControllerSourceTypeCamera || [ALAssetsLibrary authorizationStatus] == ALAuthorizationStatusAuthorized) {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no image selected"];
         } else {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to assets"];


### PR DESCRIPTION
I'm resurrecting a change from [an old pull request](https://github.com/apache/cordova-plugin-camera/pull/24) that was closed without any explanation.

[The original issue](https://issues.apache.org/jira/browse/CB-6576) has been improperly marked as resolved when it clearly is not.

Problem is there's currently no way to know when a user has just cancelled the image capture since clicking cancel send a `has no access to assets` error when it really isn't an authorization issue.