### PR TITLE
Fix FileNotFoundException in ouputModifiedBitmap

### DIFF
--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -78,7 +78,7 @@ public class FileHelper {
 
     @SuppressLint("NewApi")
     public static String getRealPathFromURI_API19(Context context, Uri uri) {
-        String filePath = "";
+        String filePath = null;
         try {
             String wholeID = DocumentsContract.getDocumentId(uri);
 
@@ -101,7 +101,7 @@ public class FileHelper {
             }
             cursor.close();
         } catch (Exception e) {
-            filePath = "";
+            filePath = null;
         }
         return filePath;
     }


### PR DESCRIPTION
The ouputModifiedBitmap expect the result from FileHelper.getRealPath to be null in case of error :

    String realPath = FileHelper.getRealPath(uri, this.cordova);
    // if realPath == "" => fileName = ""
    String fileName = realPath != null ?
            realPath.substring(realPath.lastIndexOf('/') + 1) :
            "modified." + (this.encodingType == JPEG ? "jpg" : "png");

    String modifiedPath = getTempDirectoryPath() + "/" + fileName;

    OutputStream os = new FileOutputStream(modifiedPath); <-- error when fileName == ""

This might be related to https://issues.apache.org/jira/browse/CB-9960 and https://issues.apache.org/jira/browse/CB-10093