### PR TITLE
CB-10270 android: Added back support for file:// URIs to getRealPath

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -688,11 +688,17 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
 
                         } catch (Exception e) {
                             e.printStackTrace();
-                            this.failPicture("Error retrieving image.");
+                            this.failPicture("Error modifying image");
                         }
                     }
                     else {
-                        this.callbackContext.success(fileLocation);
+                        if (fileLocation != null) {
+                            this.callbackContext.success("file://" + fileLocation);
+                        } else if (uriString != null) {
+                            this.callbackContext.success(uriString);
+                        } else {
+                            this.failPicture("Error retrieving image");
+                        }
                     }
                 }
                 if (bitmap != null) {

--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -50,7 +50,17 @@ public class FileHelper {
     public static String getRealPath(Uri uri, CordovaInterface cordova) {
         String realPath = null;
 
-        if (Build.VERSION.SDK_INT < 11)
+        if (uri.getScheme().equals("file")) {
+            String path = uri.getPath();
+            if (!path.startsWith("/android_asset/")) {
+                return path;
+            } else {
+                LOG.d(LOG_TAG, "Cannot get real path of an android_asset URI");
+                return null;
+            }
+        }
+
+        else if (Build.VERSION.SDK_INT < 11)
             realPath = FileHelper.getRealPathFromURI_BelowAPI11(cordova.getActivity(), uri);
 
         // SDK >= 11 && SDK < 19
@@ -209,7 +219,7 @@ public class FileHelper {
         }
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
     }
-    
+
     /**
      * Returns the mime type of the data specified by the given URI string.
      *


### PR DESCRIPTION
Our `getRealPath()` function is unable to handle `file: //` URIs, which can occasionally lead it to return an empty string for the result URI. These camera options reproduce when you select an image from the Gallery app:
```
{
    destinationType: Camera.DestinationType.FILE_URI,
    sourceType: Camera.PictureSourceType.PHOTOLIBRARY,
    allowEdit: true,
    correctOrientation: true
}
```
I believe that we used to do something similar to this, but it was removed at some point in the past. @infil00p do you have any idea why that was?