### PR TITLE
CB-10539 CaptureFileAsync doesn't work when maxResolution is set to v…

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -715,8 +715,8 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     }
     // Temp fix for CB-10539
     /*else if (totalPixels <= 320 * 240) {
-        maxRes = UIMaxRes.verySmallQvga;*/
-    } else if (totalPixels <= 640 * 480) {
+        maxRes = UIMaxRes.verySmallQvga;
+    }*/ else if (totalPixels <= 640 * 480) {
         maxRes = UIMaxRes.smallVga;
     } else if (totalPixels <= 1024 * 768) {
         maxRes = UIMaxRes.mediumXga;


### PR DESCRIPTION
…erySmallQvga on Windows 10

[Jira issue](https://issues.apache.org/jira/browse/CB-10539)

Fixes a typo