### PR TITLE
CB-10576: MobileSpec can't get results for Windows-Store 8.1 Builds

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -715,8 +715,9 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     }
     // Temp fix for CB-10539
     /*else if (totalPixels <= 320 * 240) {
-        maxRes = UIMaxRes.verySmallQvga;*/
-    } else if (totalPixels <= 640 * 480) {
+        maxRes = UIMaxRes.verySmallQvga;
+    }*/
+    else if (totalPixels <= 640 * 480) {
         maxRes = UIMaxRes.smallVga;
     } else if (totalPixels <= 1024 * 768) {
         maxRes = UIMaxRes.mediumXga;


### PR DESCRIPTION
Fixing a minor syntax issue

@rakatyal @riknoll @nikhilkh Could you please review and merge this PR?