### PR TITLE
Fix FileHelper / port cordova-plugin-filepath-unofficial and replace getRealPath with it

### DIFF
--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -25,6 +25,9 @@ import android.os.Build;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.webkit.MimeTypeMap;
+import android.content.ContentUris;
+import android.util.Log;
+import android.os.Environment;
 
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.LOG;
@@ -33,6 +36,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
+import java.util.List;
+import java.io.File;
 
 public class FileHelper {
     private static final String LOG_TAG = "FileUtils";
@@ -50,16 +55,7 @@ public class FileHelper {
     public static String getRealPath(Uri uri, CordovaInterface cordova) {
         String realPath = null;
 
-        if (Build.VERSION.SDK_INT < 11)
-            realPath = FileHelper.getRealPathFromURI_BelowAPI11(cordova.getActivity(), uri);
-
-        // SDK >= 11 && SDK < 19
-        else if (Build.VERSION.SDK_INT < 19)
-            realPath = FileHelper.getRealPathFromURI_API11to18(cordova.getActivity(), uri);
-
-        // SDK > 19 (Android 4.4)
-        else
-            realPath = FileHelper.getRealPathFromURI_API19(cordova.getActivity(), uri);
+        realPath = FileHelper.getPath(cordova.getActivity(), uri);
 
         return realPath;
     }
@@ -76,70 +72,249 @@ public class FileHelper {
         return FileHelper.getRealPath(Uri.parse(uriString), cordova);
     }
 
-    @SuppressLint("NewApi")
-    public static String getRealPathFromURI_API19(Context context, Uri uri) {
-        String filePath = "";
-        try {
-            String wholeID = DocumentsContract.getDocumentId(uri);
+    /**
+     * Get a file path from a Uri. This will get the the path for Storage Access
+     * Framework Documents, as well as the _data field for the MediaStore and
+     * other file-based ContentProviders.<br>
+     * <br>
+     * Callers should check whether the path is local before assuming it
+     * represents a local file.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     */
+    private static String getPath(final Context context, final Uri uri) {
 
-            // Split at colon, use second item in the array
-            String id = wholeID.indexOf(":") > -1 ? wholeID.split(":")[1] : wholeID.indexOf(";") > -1 ? wholeID
-                    .split(";")[1] : wholeID;
+        Log.d(LOG_TAG, "File - " +
+                "Authority: " + uri.getAuthority() +
+                        ", Fragment: " + uri.getFragment() +
+                        ", Port: " + uri.getPort() +
+                        ", Query: " + uri.getQuery() +
+                        ", Scheme: " + uri.getScheme() +
+                        ", Host: " + uri.getHost() +
+                        ", Segments: " + uri.getPathSegments().toString()
+        );
 
-            String[] column = { MediaStore.Images.Media.DATA };
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
-            // where id is equal to
-            String sel = MediaStore.Images.Media._ID + "=?";
+        // DocumentProvider
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
 
-            Cursor cursor = context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, column,
-                    sel, new String[] { id }, null);
-
-            int columnIndex = cursor.getColumnIndex(column[0]);
-
-            if (cursor.moveToFirst()) {
-                filePath = cursor.getString(columnIndex);
+                String fullPath = getPathFromExtSD(split);
+                if (fullPath != "") {
+                    return fullPath;
+                }
+                else {
+                    return null;
+                }
             }
-            cursor.close();
-        } catch (Exception e) {
-            filePath = "";
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                return getDataColumn(context, contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                        split[1]
+                };
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+            else if (isGoogleDriveUri(uri)) {
+                return null;
+            }
         }
-        return filePath;
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+            // Return the remote address
+            if (isGooglePhotosUri(uri)) {
+                String contentPath = getContentFromSegments(uri.getPathSegments());
+                if (contentPath != "") {
+                    return getPath(context, Uri.parse(contentPath));
+                }
+                else {
+                    return null;
+                }
+            }
+
+            return getDataColumn(context, uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
     }
 
-    @SuppressLint("NewApi")
-    public static String getRealPathFromURI_API11to18(Context context, Uri contentUri) {
-        String[] proj = { MediaStore.Images.Media.DATA };
-        String result = null;
+    /**
+     * Get full file path from external storage
+     *
+     * @param pathData The storage type and the relative path
+     */
+    private static String getPathFromExtSD(String[] pathData) {
+        final String type = pathData[0];
+        final String relativePath = "/" + pathData[1];
+        String fullPath = "";
 
-        try {
-            CursorLoader cursorLoader = new CursorLoader(context, contentUri, proj, null, null, null);
-            Cursor cursor = cursorLoader.loadInBackground();
-
-            if (cursor != null) {
-                int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
-                cursor.moveToFirst();
-                result = cursor.getString(column_index);
+        // on my Sony devices (4.4.4 & 5.1.1), `type` is a dynamic string
+        // something like "71F8-2C0A", some kind of unique id per storage
+        // don't know any API that can get the root path of that storage based on its id.
+        //
+        // so no "primary" type, but let the check here for other devices
+        if ("primary".equalsIgnoreCase(type)) {
+            fullPath = Environment.getExternalStorageDirectory() + relativePath;
+            if (fileExists(fullPath)) {
+                return fullPath;
             }
-        } catch (Exception e) {
-            result = null;
         }
-        return result;
+    
+        // Environment.isExternalStorageRemovable() is `true` for external and internal storage
+        // so we cannot relay on it.
+        //
+        // instead, for each possible path, check if file exists
+        // we'll start with secondary storage as this could be our (physically) removable sd card
+        fullPath = System.getenv("SECONDARY_STORAGE") + relativePath;
+        if (fileExists(fullPath)) {
+            return fullPath;
+        }
+
+        fullPath = System.getenv("EXTERNAL_STORAGE") + relativePath;
+        if (fileExists(fullPath)) {
+            return fullPath;
+        }
+
+        return fullPath;
     }
 
-    public static String getRealPathFromURI_BelowAPI11(Context context, Uri contentUri) {
-        String[] proj = { MediaStore.Images.Media.DATA };
-        String result = null;
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     * @param selection (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     */
+    private static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = _DATA;
+        final String[] projection = {
+                column
+        };
 
         try {
-            Cursor cursor = context.getContentResolver().query(contentUri, proj, null, null, null);
-            int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
-            cursor.moveToFirst();
-            result = cursor.getString(column_index);
-
-        } catch (Exception e) {
-            result = null;
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
         }
-        return result;
+        return null;
+    }
+
+    /**
+     * Get content:// from segment list
+     * In the new Uri Authority of Google Photos, the last segment is not the content:// anymore
+     * So let's iterate through all segments and find the content uri!
+     *
+     * @param segments The list of segment
+     */
+    private static String getContentFromSegments(List<String> segments) {
+        String contentPath = "";
+
+        for(String item : segments) {
+            if (item.startsWith("content://")) {
+                contentPath = item;
+                break;
+            }
+        }
+
+        return contentPath;
+    }
+
+    /**
+     * Check if a file exists on device
+     *
+     * @param filePath The absolute file path
+     */
+    private static boolean fileExists(String filePath) {
+        File file = new File(filePath);
+
+        return file.exists();
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    private static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Photos.
+     */
+    private static boolean isGooglePhotosUri(Uri uri) {
+        return ("com.google.android.apps.photos.content".equals(uri.getAuthority())
+                || "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority()));
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Drive.
+     */
+    private static boolean isGoogleDriveUri(Uri uri) {
+        return "com.google.android.apps.docs.storage".equals(uri.getAuthority());
     }
 
     /**
@@ -209,7 +384,7 @@ public class FileHelper {
         }
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
     }
-    
+
     /**
      * Returns the mime type of the data specified by the given URI string.
      *


### PR DESCRIPTION
I recently encountered the `FileNotFoundException ouputModifiedBitmap` error while using this plugin and I've tried all PRs available here but none seems to fix the issue.
The current implementation of FileHelper does not deal well with files from external (and even internal) SD card (removable or not).
I also had issues getting videos file paths.

I was using [cordova-plugin-filepath](https://github.com/TanaseButcaru/cordova-plugin-filepath-unofficial) to get the `file://` path from a `content://` one. 
This plugin had its one issues, which I managed to fix & improve it as a whole. 

Because the filepath plugin is doing its job well, I ported it to the cordova-plugin-camera. This looks a lot like PR #93 , just that it is updated.
The only case where this fails (as far as I have tested) is the case when user selects a picture/video from Google Drive (there's no solution for this in #143 PR too).

This closes the following:
- #160 
- #155 
- #149
- #148 
- #143 
- #135 
- #112 
- #93  

You can test this PR & the #169 PR from my [unofficial version release](https://github.com/TanaseButcaru/cordova-plugin-camera-unofficial) of cordova-plugin-camera.
