### PR TITLE
fix(android): Create Pictures directory if it doesn't exist

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -550,6 +550,9 @@ private String getPicutresPath()
     String imageFileName = "IMG_" + timeStamp + (this.encodingType == JPEG ? ".jpg" : ".png");
     File storageDir = Environment.getExternalStoragePublicDirectory(
             Environment.DIRECTORY_PICTURES);
+    if (!storageDir.exists() && !storageDir.mkdir()) {
+        Log.e(LOG_TAG, "Error creating directory: " + storageDir.toURI().toASCIIString());
+    }
     String galleryPath = storageDir.getAbsolutePath() + "/" + imageFileName;
     return galleryPath;
 }


### PR DESCRIPTION
Possibly should throw an exception if the directory can't be created. A log message is emitted and behavior is no worse than current code.
