### PR TITLE
CB-10120 android: Camera permission must be requested when present in Manifest

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -58,6 +58,9 @@ import android.provider.MediaStore;
 import android.util.Base64;
 import android.util.Log;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.PermissionInfo;
+
 /**
  * This class launches the camera view, allows the user to take a picture, closes the camera view,
  * and returns the captured image.  When the camera view is closed, the screen displayed before
@@ -105,7 +108,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private boolean orientationCorrected;   // Has the picture's orientation been corrected
     private boolean allowEdit;              // Should we allow the user to crop the image.
 
-    protected final static String[] permissions = { Manifest.permission.READ_EXTERNAL_STORAGE };
+    protected final static String[] permissions = { Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE };
 
     public CallbackContext callbackContext;
     private int numPics;
@@ -113,6 +116,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private MediaScannerConnection conn;    // Used to update gallery app with newly-written files
     private Uri scanMe;                     // Uri of image to be added to content store
     private Uri croppedUri;
+
+    protected void getReadPermission(int requestCode)
+    {
+        cordova.requestPermission(this, requestCode, permissions[requestCode]);
+    }
 
     /**
      * Executes the request and returns PluginResult.
@@ -172,8 +180,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     // preserve the original exif data and filename in the modified file that is
                     // created
                     if(this.mediaType == PICTURE && (this.destType == FILE_URI || this.destType == NATIVE_URI)
-                            && fileWillBeModified() && !PermissionHelper.hasPermission(this, permissions[0])) {
-                        PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
+                            && fileWillBeModified() && !cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC])) {
+                        getReadPermission(SAVE_TO_ALBUM_SEC);
                     } else {
                         this.getImage(this.srcType, destType, encodingType);
                     }
@@ -232,13 +240,40 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      */
     public void callTakePicture(int returnType, int encodingType) {
-        if (PermissionHelper.hasPermission(this, permissions[0])) {
+		boolean takePicturePermission = cordova.hasPermission(permissions[TAKE_PIC_SEC]);
+
+		if (!takePicturePermission) {
+			takePicturePermission = true; // This permission is not required, unless we find android.permission.CAMERA in the package
+			try {
+				PackageManager packageManager = this.cordova.getActivity().getPackageManager();
+				String[] permissionsInPackage = packageManager.getPackageInfo(this.cordova.getActivity().getPackageName(), PackageManager.GET_PERMISSIONS).requestedPermissions;
+				if (permissionsInPackage != null) {
+					for (String permission : permissionsInPackage) {
+						if (permission.equals(Manifest.permission.CAMERA)) {
+							takePicturePermission = false;
+							break;
+						}
+					}
+				}
+			} catch (NameNotFoundException e) {	} 			
+		}
+
+		boolean saveAlbumPermission = cordova.hasPermission(permissions[SAVE_TO_ALBUM_SEC]);
+        if (takePicturePermission && saveAlbumPermission) {
             takePicture(returnType, encodingType);
         } else {
-            PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
+			if (saveAlbumPermission && !takePicturePermission) {
+				cordova.requestPermission(this, TAKE_PIC_SEC, permissions[TAKE_PIC_SEC]);
+			}
+			else if (!saveAlbumPermission && takePicturePermission) {
+				cordova.requestPermission(this, TAKE_PIC_SEC, permissions[SAVE_TO_ALBUM_SEC]);
+			}
+			else
+			{
+				cordova.requestPermissions(this, TAKE_PIC_SEC, permissions);
+			}
         }
     }
-
 
     public void takePicture(int returnType, int encodingType)
     {


### PR DESCRIPTION
Because three PRs are better than one.

This provides fixes for #142 and is based on top of the rebase in #174 

I will merge this in soon