### PR TITLE
Adding focus handler to make sure filepicker gets launched when app i…

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -731,21 +731,32 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
 
     cameraCaptureUI.photoSettings.maxResolution = maxRes;
 
-    cameraCaptureUI.captureFileAsync(WMCapture.CameraCaptureUIMode.photo).done(function(picture) {
-        if (!picture) {
-            errorCallback("User didn't capture a photo.");
-            return;
-        }
+    var cameraPicture;
+    var savePhotoOnFocus = function() {
 
-        savePhoto(picture, {
+        window.removeEventListener("focus", savePhotoOnFocus);
+        // call only when the app is in focus again
+        savePhoto(cameraPicture, {
             destinationType: destinationType,
             targetHeight: targetHeight,
             targetWidth: targetWidth,
             encodingType: encodingType,
             saveToPhotoAlbum: saveToPhotoAlbum
         }, successCallback, errorCallback);
+    }
+
+    // add and delete focus eventHandler to capture the focus back from cameraUI to app 
+    window.addEventListener("focus", savePhotoOnFocus);
+    cameraCaptureUI.captureFileAsync(WMCapture.CameraCaptureUIMode.photo).done(function(picture) {
+        if (!picture) {
+            errorCallback("User didn't capture a photo.");
+            window.removeEventListener("focus", savePhotoOnFocus);
+            return;
+        }
+        cameraPicture = picture;
     }, function() {
         errorCallback("Fail to capture a photo.");
+        window.removeEventListener("focus", savePhotoOnFocus);
     });
 }
 


### PR DESCRIPTION
…s active

FilesavePicker gives error when launched from an app which is currently not active. When the capture is complete after launching CameraUI (the app becomes inactive when cameraUI is launched), we immediately launch filesavepicker introducing a race condition, in which sometimes the savepicker gets launched when the app hasn't reached the active state yet causing it to break.
We should only launch it once the app becomes active again. 