### PR TITLE
Blackberry camera fix

### DIFF
--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -245,6 +245,9 @@ module.exports = {
 
                                 data = canvas.toDataURL('image/jpeg');
                                 data = data.slice(data.indexOf(",") + 1);
+
+                                canvas = null;
+                                img = null;
                                 result.callbackOk(data, false);
                             }
 

--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -198,6 +198,7 @@ module.exports = {
 
                                 var ratiox = canvas.height/this.width;
                                 var ratioy = canvas.width/this.height;
+                                var toWidth, toHeight, toLeft, toTop;
 
                                 // front camera used, assumed on photo size, it works with BB Z10
                                 // @todo use exif informations to get more information about the picture
@@ -205,17 +206,17 @@ module.exports = {
 
                                     // source is wider than destination
                                     if (ratiox > ratioy) {
-                                        var toWidth = canvas.height;
-                                        var toHeight = (this.height/this.width)*canvas.height;
-                                        var toTop = (canvas.width-toHeight)/2;
-                                        var toLeft = -canvas.height;
+                                        toWidth = canvas.height;
+                                        toHeight = (this.height/this.width)*canvas.height;
+                                        toTop = (canvas.width-toHeight)/2;
+                                        toLeft = -canvas.height;
                                     }
                                     // source is higher than destination
                                     else {
-                                        var toHeight = canvas.width;
-                                        var toWidth = (this.width/this.height)*canvas.width;
-                                        var toTop = 0;
-                                        var toLeft = (canvas.height + (toWidth-canvas.height)/2)*-1;
+                                        toHeight = canvas.width;
+                                        toWidth = (this.width/this.height)*canvas.width;
+                                        toTop = 0;
+                                        toLeft = (canvas.height + (toWidth-canvas.height)/2)*-1;
                                     }
 
                                     ctx.rotate(-90*Math.PI/180);
@@ -226,17 +227,17 @@ module.exports = {
                                     // source is wider than destination
                                     if (ratiox > ratioy) {
                                         console.log('first 2');
-                                        var toWidth = canvas.height;
-                                        var toHeight = (this.height/this.width)*canvas.height;
-                                        var toTop = (canvas.width+ ((toHeight-canvas.width)/2))*-1;
-                                        var toLeft = 0;//(canvas.width-toHeight)/2;
+                                        toWidth = canvas.height;
+                                        toHeight = (this.height/this.width)*canvas.height;
+                                        toTop = (canvas.width+ ((toHeight-canvas.width)/2))*-1;
+                                        toLeft = 0;//(canvas.width-toHeight)/2;
                                     }
                                     // source is higher than destination
                                     else {
-                                        var toHeight = canvas.width;
-                                        var toWidth = (this.width/this.height)*canvas.width;
-                                        var toTop = -canvas.width; //
-                                        var toLeft = (canvas.height-toWidth)/2;
+                                        toHeight = canvas.width;
+                                        toWidth = (this.width/this.height)*canvas.width;
+                                        toTop = -canvas.width; //
+                                        toLeft = (canvas.height-toWidth)/2;
                                     }
 
                                     ctx.rotate(90*Math.PI/180);
@@ -249,7 +250,7 @@ module.exports = {
                                 canvas = null;
                                 img = null;
                                 result.callbackOk(data, false);
-                            }
+                            };
 
                             img.src = data;
 

--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -184,8 +184,72 @@ module.exports = {
                 } else {
                     encodeBase64(data, function (data) {
                         if (/^data:/.test(data)) {
-                            data = data.slice(data.indexOf(",") + 1);
-                            result.callbackOk(data, false);
+                            
+                            var img = new Image();
+
+                            img.onload = function() {
+
+                                var canvas=document.createElement("canvas");
+                                var ctx = canvas.getContext('2d');
+
+                                // use the required picture size, from the parameters
+                                canvas.width = args[3];
+                                canvas.height = args[4];
+
+                                var ratiox = canvas.height/this.width;
+                                var ratioy = canvas.width/this.height;
+
+                                // front camera used, assumed on photo size, it works with BB Z10
+                                // @todo use exif informations to get more information about the picture
+                                if ( this.width < 2000 && this.height < 1000) {
+
+                                    // source is wider than destination
+                                    if (ratiox > ratioy) {
+                                        var toWidth = canvas.height;
+                                        var toHeight = (this.height/this.width)*canvas.height;
+                                        var toTop = (canvas.width-toHeight)/2;
+                                        var toLeft = -canvas.height;
+                                    }
+                                    // source is higher than destination
+                                    else {
+                                        var toHeight = canvas.width;
+                                        var toWidth = (this.width/this.height)*canvas.width;
+                                        var toTop = 0;
+                                        var toLeft = (canvas.height + (toWidth-canvas.height)/2)*-1;
+                                    }
+
+                                    ctx.rotate(-90*Math.PI/180);
+                                    ctx.drawImage(this, toLeft, toTop, toWidth, toHeight);
+                                }
+                                else {
+
+                                    // source is wider than destination
+                                    if (ratiox > ratioy) {
+                                        console.log('first 2');
+                                        var toWidth = canvas.height;
+                                        var toHeight = (this.height/this.width)*canvas.height;
+                                        var toTop = (canvas.width+ ((toHeight-canvas.width)/2))*-1;
+                                        var toLeft = 0;//(canvas.width-toHeight)/2;
+                                    }
+                                    // source is higher than destination
+                                    else {
+                                        var toHeight = canvas.width;
+                                        var toWidth = (this.width/this.height)*canvas.width;
+                                        var toTop = -canvas.width; //
+                                        var toLeft = (canvas.height-toWidth)/2;
+                                    }
+
+                                    ctx.rotate(90*Math.PI/180);
+                                    ctx.drawImage(this, toLeft, toTop, toWidth, toHeight);
+                                }
+
+                                data = canvas.toDataURL('image/jpeg');
+                                data = data.slice(data.indexOf(",") + 1);
+                                result.callbackOk(data, false);
+                            }
+
+                            img.src = data;
+
                         } else {
                             result.callbackError(data, false);
                         }

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -688,6 +688,7 @@ function takePictureFromCameraWP(successCallback, errorCallback, args) {
 }
 
 function takePictureFromCameraWindows(successCallback, errorCallback, args) {
+
     var destinationType = args[1],
         targetWidth = args[3],
         targetHeight = args[4],
@@ -731,22 +732,29 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
 
     cameraCaptureUI.photoSettings.maxResolution = maxRes;
 
-    cameraCaptureUI.captureFileAsync(WMCapture.CameraCaptureUIMode.photo).done(function(picture) {
-        if (!picture) {
-            errorCallback("User didn't capture a photo.");
-            return;
-        }
+    cameraCaptureUI.captureFileAsync(WMCapture.CameraCaptureUIMode.photo).done(
 
-        savePhoto(picture, {
-            destinationType: destinationType,
-            targetHeight: targetHeight,
-            targetWidth: targetWidth,
-            encodingType: encodingType,
-            saveToPhotoAlbum: saveToPhotoAlbum
-        }, successCallback, errorCallback);
-    }, function() {
-        errorCallback("Fail to capture a photo.");
-    });
+        function(picture) {
+
+            if (!picture) {
+                errorCallback("User didn't capture a photo.");
+                return;
+            }
+
+            savePhoto(picture, {
+                destinationType: destinationType,
+                targetHeight: targetHeight,
+                targetWidth: targetWidth,
+                encodingType: encodingType,
+                saveToPhotoAlbum: saveToPhotoAlbum
+                }, successCallback, errorCallback
+            );
+
+        }, function() {
+
+            errorCallback("Fail to capture a photo.");
+        }
+    );
 }
 
 function savePhoto(picture, options, successCallback, errorCallback) {


### PR DESCRIPTION
Fixes:
 - Rotate the picture to the proper position (it was always rotated with 90 degrees)
 - Resize the picture to the configured size (the original code ignored the configuration)

Known issues:
 - The plugin tested only on BB Z10
 - The camera detection doesn't use exif informations, i'm using a small hack