### PR TITLE
CB-10825 android: Always request READ permission for gallery source

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -168,11 +168,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     this.callTakePicture(destType, encodingType);
                 }
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
-                    // Any options that edit the file require READ permissions in order to try and
-                    // preserve the original exif data and filename in the modified file that is
-                    // created
-                    if(this.mediaType == PICTURE && (this.destType == FILE_URI || this.destType == NATIVE_URI)
-                            && fileWillBeModified() && !PermissionHelper.hasPermission(this, permissions[0])) {
+                    // FIXME: Stop always requesting the permission
+                    if(!PermissionHelper.hasPermission(this, permissions[0])) {
                         PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
                     } else {
                         this.getImage(this.srcType, destType, encodingType);
@@ -1202,11 +1199,6 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
                 this.getImage(this.srcType, this.destType, this.encodingType);
                 break;
         }
-    }
-
-    private boolean fileWillBeModified() {
-        return (this.targetWidth > 0 && this.targetHeight > 0) ||
-                    this.correctOrientation || this.allowEdit;
     }
 
     /**


### PR DESCRIPTION
I am unhappy with this change, but this issue is blocking a release and a proper fix could end up being a major rewrite to how we do permissions. The issue at the center of this is that whether or not we need the READ permission changes according to the camera options passed to `getPicture()` and the app used to select a photo. We need to fix how we request permissions so that we request them *after* the photo is selected, and only when we need them. 

Really, the bigger issue is that we try and convert all `content://` URIs into real file paths. As I understand it, Content resolvers are not intended for that purpose.