### PR TITLE
Making focus handlers to only work for Windows 10 phone

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -745,8 +745,9 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     cameraCaptureUI.photoSettings.maxResolution = maxRes;
 
     var cameraPicture;
-    var savePhotoOnFocus = function() {
-
+    
+    // define focus handler for windows phone 10.0
+    var savePhotoOnFocus = function () {
         window.removeEventListener("focus", savePhotoOnFocus);
         // call only when the app is in focus again
         savePhoto(cameraPicture, {
@@ -758,16 +759,31 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
         }, successCallback, errorCallback);
     };
 
-    // add and delete focus eventHandler to capture the focus back from cameraUI to app 
-    window.addEventListener("focus", savePhotoOnFocus);
-    cameraCaptureUI.captureFileAsync(WMCapture.CameraCaptureUIMode.photo).done(function(picture) {
+    // if windows phone 10, add and delete focus eventHandler to capture the focus back from cameraUI to app
+    if (navigator.appVersion.indexOf('Windows Phone 10.0') >= 0) { 
+        window.addEventListener("focus", savePhotoOnFocus);
+    }
+
+    cameraCaptureUI.captureFileAsync(WMCapture.CameraCaptureUIMode.photo).done(function (picture) {
         if (!picture) {
             errorCallback("User didn't capture a photo.");
+            // Remove the focus handler if present
             window.removeEventListener("focus", savePhotoOnFocus);
             return;
         }
         cameraPicture = picture;
-    }, function() {
+
+        // If not windows 10, call savePhoto() now. If windows 10, wait for the app to be in focus again
+        if (navigator.appVersion.indexOf('Windows Phone 10.0') < 0) {
+            savePhoto(cameraPicture, {
+                destinationType: destinationType,
+                targetHeight: targetHeight,
+                targetWidth: targetWidth,
+                encodingType: encodingType,
+                saveToPhotoAlbum: saveToPhotoAlbum
+            }, successCallback, errorCallback);
+        }
+    }, function () {
         errorCallback("Fail to capture a photo.");
         window.removeEventListener("focus", savePhotoOnFocus);
     });


### PR DESCRIPTION
The focus handler behave differently on Win 8.1, so making the change to  work only in case for windows 10 phone.