### PR TITLE
CB-10857 android : Camera.getPicture return null for Google Drive (camera 2.1.1)

### DIFF
--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -59,6 +59,10 @@ public class FileHelper {
         else
             realPath = FileHelper.getRealPathFromURI_API11_And_Above(cordova.getActivity(), uri);
 
+        //Return the URI string if no other type of path has been found
+        if(realPath == null)
+            realPath =  uri.toString();
+
         return realPath;
     }
 


### PR DESCRIPTION
FileHelper getRealPath will fallback to URI string if no other type of
path has been found
