### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -65,7 +65,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18"/>
         </config-file>
 
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />
@@ -87,7 +87,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" />
         </config-file>
 
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />


### PR DESCRIPTION
In principle Cordova should not use a permission where it is no longer relevant as it might leave things less secure.

You can see this documentation here http://developer.android.com/guide/topics/manifest/uses-permission-element.html

Note the following in the documentation:
# 

android:maxSdkVersion
The highest API level at which this permission should be granted to your app. Setting this attribute is useful if the permission your app requires is no longer needed beginning at a certain API level.
For example, beginning with Android 4.4 (API level 19), it's no longer necessary for your app to request the WRITE_EXTERNAL_STORAGE permission when your app wants to write to its own application-specific directories on external storage (the directories provided by getExternalFilesDir()). However, the permission is required for API level 18 and lower. So you can declare that this permission is needed only up to API level 18 with a declaration such as this:

<uses-permission
     android:name="android.permission.WRITE_EXTERNAL_STORAGE"
     android:maxSdkVersion="18" />
This way, beginning with API level 19, the system will no longer grant your app the WRITE_EXTERNAL_STORAGE permission.
# This attribute was added in API level 19.
