### PR TITLE
Set android quality default value to 50 on the java code

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -138,7 +138,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             this.targetWidth = 0;
             this.encodingType = JPEG;
             this.mediaType = PICTURE;
-            this.mQuality = 80;
+            this.mQuality = 50;
 
             //Take the values from the arguments if they're not already defined (this is tricky)
             this.destType = args.getInt(1);


### PR DESCRIPTION
Default value is set to 80 on the java code, but doc says that default
value is 50.

I’m changing it just for making code clearer, but default value is set
to 50 to all platforms in Camera.js if no value is passed