### PR TITLE
Dont work camera on Android

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,12 @@
+<!--
+Please make sure the checklist boxes are all checked before submitting the PR. The checklist
+is intended as a quick reference, for complete details please see our Contributor Guidelines:
+
+http://cordova.apache.org/contribute/contribute_guidelines.html
+
+Thanks!
+-->
+
 ### Platforms affected
 
 
@@ -8,8 +17,7 @@
 
 
 ### Checklist
-Please make sure these boxes are checked before submitting the PR. This checklist is intended as a quick reference, for complete details please see our [Contributor Guidelines](http://cordova.apache.org/contribute/contribute_guidelines.html). Thanks!
 - [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
-- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database 
+- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
 - [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
-- [ ] Add automated test coverage as appropriate for this change.
+- [ ] Added automated test coverage as appropriate for this change.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Platforms affected
+
+
+### What does this PR do?
+
+
+### What testing has been done on this change?
+
+
+### Checklist
+Please make sure these boxes are checked before submitting the PR. This checklist is intended as a quick reference, for complete details please see our [Contributor Guidelines](http://cordova.apache.org/contribute/contribute_guidelines.html). Thanks!
+- [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
+- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database 
+- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
+- [ ] Add automated test coverage as appropriate for this change.

--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ Documentation consists of template and API docs produced from the plugin JS code
     * [.PictureSourceType](#module_Camera.PictureSourceType) : <code>enum</code>
     * [.PopoverArrowDirection](#module_Camera.PopoverArrowDirection) : <code>enum</code>
     * [.Direction](#module_Camera.Direction) : <code>enum</code>
+    
+* [CameraPopoverOptions](#module_CameraPopoverOptions)
 
 * [CameraPopoverHandle](#module_CameraPopoverHandle)
-* [CameraPopoverOptions](#module_CameraPopoverOptions)
+	* [.setPosition(options)](#module_CameraPopoverHandle.setPosition)
 
 ---
 
@@ -116,10 +118,7 @@ Once the user snaps the photo, the camera application closes and the application
 
 If `Camera.sourceType` is `Camera.PictureSourceType.PHOTOLIBRARY` or
 `Camera.PictureSourceType.SAVEDPHOTOALBUM`, then a dialog displays
-that allows users to select an existing image.  The
-`camera.getPicture` function returns a [`CameraPopoverHandle`](#module_CameraPopoverHandle) object,
-which can be used to reposition the image selection dialog, for
-example, when the device orientation changes.
+that allows users to select an existing image.
 
 The return value is sent to the [`cameraSuccess`](#module_camera.onSuccess) callback function, in
 one of the following formats, depending on the specified
@@ -364,7 +363,17 @@ location.
 <a name="module_CameraPopoverHandle"></a>
 
 ## CameraPopoverHandle
-A handle to an image picker popover.
+A handle to the image picker popover.
+
+<a name="module_CameraPopoverHandle.setPosition"></a>
+
+### CameraPopoverHandle.setPosition(options)
+Can be used to reposition the image selection dialog, for example, when the device orientation changes.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>[CameraPopoverOptions](#module_CameraPopoverOptions)</code> | CameraPopoverOptions |
 
 __Supported Platforms__
 
@@ -372,7 +381,7 @@ __Supported Platforms__
 
 **Example**  
 ```js
-var cameraPopoverHandle = navigator.camera.getPicture(onSuccess, onFail,
+navigator.camera.getPicture(onSuccess, onFail,
 {
     destinationType: Camera.DestinationType.FILE_URI,
     sourceType: Camera.PictureSourceType.PHOTOLIBRARY,
@@ -381,6 +390,7 @@ var cameraPopoverHandle = navigator.camera.getPicture(onSuccess, onFail,
 
 // Reposition the popover if the orientation changes.
 window.onorientationchange = function() {
+    var cameraPopoverHandle = new CameraPopoverHandle();
     var cameraPopoverOptions = new CameraPopoverOptions(0, 0, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY);
     cameraPopoverHandle.setPosition(cameraPopoverOptions);
 }

--- a/README.md
+++ b/README.md
@@ -305,9 +305,9 @@ change, cropping, etc.) due to implementation specific.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| PHOTOLIBRARY | <code>number</code> | <code>0</code> | Choose image from picture library (same as SAVEDPHOTOALBUM for Android) |
+| PHOTOLIBRARY | <code>number</code> | <code>0</code> | Choose image from the device's photo library (same as SAVEDPHOTOALBUM for Android) |
 | CAMERA | <code>number</code> | <code>1</code> | Take picture from camera |
-| SAVEDPHOTOALBUM | <code>number</code> | <code>2</code> | Choose image from picture library (same as PHOTOLIBRARY for Android) |
+| SAVEDPHOTOALBUM | <code>number</code> | <code>2</code> | Choose image only from the device's Camera Roll album (same as PHOTOLIBRARY for Android) |
 
 <a name="module_Camera.PopoverArrowDirection"></a>
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Documentation consists of template and API docs produced from the plugin JS code
 
 ---
 
-# API Reference
+# API Reference <a name="reference"></a>
 
 
 * [camera](#module_camera)
@@ -98,10 +98,8 @@ Documentation consists of template and API docs produced from the plugin JS code
 ---
 
 <a name="module_camera"></a>
-
 ## camera
 <a name="module_camera.getPicture"></a>
-
 ### camera.getPicture(successCallback, errorCallback, options)
 Takes a photo using the camera, or retrieves a photo from the device's
 image gallery.  The image is passed to the success callback as a
@@ -169,7 +167,6 @@ More examples [here](#camera-getPicture-examples). Quirks [here](#camera-getPict
 navigator.camera.getPicture(cameraSuccess, cameraError, cameraOptions);
 ```
 <a name="module_camera.cleanup"></a>
-
 ### camera.cleanup()
 Removes intermediate image files that are kept in temporary storage
 after calling [`camera.getPicture`](#module_camera.getPicture). Applies only when the value of
@@ -194,7 +191,6 @@ function onFail(message) {
 }
 ```
 <a name="module_camera.onError"></a>
-
 ### camera.onError : <code>function</code>
 Callback function that provides an error message.
 
@@ -205,7 +201,6 @@ Callback function that provides an error message.
 | message | <code>string</code> | The message is provided by the device's native code. |
 
 <a name="module_camera.onSuccess"></a>
-
 ### camera.onSuccess : <code>function</code>
 Callback function that provides the image data.
 
@@ -225,7 +220,6 @@ function cameraCallback(imageData) {
 }
 ```
 <a name="module_camera.CameraOptions"></a>
-
 ### camera.CameraOptions : <code>Object</code>
 Optional parameters to customize the camera settings.
 * [Quirks](#CameraOptions-quirks)
@@ -251,10 +245,8 @@ Optional parameters to customize the camera settings.
 ---
 
 <a name="module_Camera"></a>
-
 ## Camera
 <a name="module_Camera.DestinationType"></a>
-
 ### Camera.DestinationType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -266,7 +258,6 @@ Optional parameters to customize the camera settings.
 | NATIVE_URI | <code>number</code> | <code>2</code> | Return native uri (eg. asset-library://... for iOS) |
 
 <a name="module_Camera.EncodingType"></a>
-
 ### Camera.EncodingType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -277,7 +268,6 @@ Optional parameters to customize the camera settings.
 | PNG | <code>number</code> | <code>1</code> | Return PNG encoded image |
 
 <a name="module_Camera.MediaType"></a>
-
 ### Camera.MediaType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -289,7 +279,6 @@ Optional parameters to customize the camera settings.
 | ALLMEDIA | <code>number</code> | <code>2</code> | Allow selection from all media types |
 
 <a name="module_Camera.PictureSourceType"></a>
-
 ### Camera.PictureSourceType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -301,7 +290,6 @@ Optional parameters to customize the camera settings.
 | SAVEDPHOTOALBUM | <code>number</code> | <code>2</code> | Choose image from picture library (same as PHOTOLIBRARY for Android) |
 
 <a name="module_Camera.PopoverArrowDirection"></a>
-
 ### Camera.PopoverArrowDirection : <code>enum</code>
 Matches iOS UIPopoverArrowDirection constants to specify arrow location on popover.
 
@@ -317,7 +305,6 @@ Matches iOS UIPopoverArrowDirection constants to specify arrow location on popov
 | ARROW_ANY | <code>number</code> | <code>15</code> | 
 
 <a name="module_Camera.Direction"></a>
-
 ### Camera.Direction : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -330,7 +317,6 @@ Matches iOS UIPopoverArrowDirection constants to specify arrow location on popov
 ---
 
 <a name="module_CameraPopoverOptions"></a>
-
 ## CameraPopoverOptions
 iOS-only parameters that specify the anchor element location and arrow
 direction of the popover when selecting images from an iPad's library
@@ -352,7 +338,6 @@ location.
 ---
 
 <a name="module_CameraPopoverHandle"></a>
-
 ## CameraPopoverHandle
 A handle to an image picker popover.
 
@@ -618,7 +603,7 @@ function displayImage(imgUri) {
 }
 ```
 
-To display the image on some platforms, you might need to include the main part of the URI in the Content-Security-Policy <meta> element in index.html. For example, on Windows 10, you can include `ms-appdata:` in your <meta> element. Here is an example.
+To display the image on some platforms, you might need to include the main part of the URI in the Content-Security-Policy `<meta>` element in index.html. For example, on Windows 10, you can include `ms-appdata:` in your `<meta>` element. Here is an example.
 
 ```html
 <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: ms-appdata: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">

--- a/README.md
+++ b/README.md
@@ -526,3 +526,202 @@ Tizen only supports a `destinationType` of
 [web_activities]: https://hacks.mozilla.org/2013/01/introducing-web-activities/
 [wp8_bug]: https://issues.apache.org/jira/browse/CB-2083
 [msdn_wp8_docs]: http://msdn.microsoft.com/en-us/library/windowsphone/develop/hh394006.aspx
+
+## Sample: Take Pictures, Select Pictures from the Picture Library, and Get Thumbnails <a name="sample"></a>
+
+The Camera plugin allows you to do things like open the device's Camera app and take a picture, or open the file picker and select one. The code snippets in this section demonstrate different tasks including:
+
+* Open the Camera app and [take a Picture](#takePicture)
+* Take a picture and [return thumbnails](#getThumbnails) (resized picture)
+* Take a picture and [generate a FileEntry object](#convert)
+* [Select a file](#selectFile) from the picture library
+* Select a JPEG image and [return thumbnails](#getFileThumbnails) (resized image)
+* Select an image and [generate a FileEntry object](#convert)
+
+## Take a Picture <a name="takePicture"></a>
+
+Before you can take a picture, you need to set some Camera plugin options to pass into the Camera plugin's `getPicture` function. Here is a common set of recommendations. In this example, you create the object that you will use for the Camera options, and set the `sourceType` dynamically to support both the Camera app and the file picker.
+
+```js
+function setOptions(srcType) {
+    var options = {
+        // Some common settings are 20, 50, and 100
+        quality: 50,
+        destinationType: Camera.DestinationType.FILE_URI,
+        // In this app, dynamically set the picture source, Camera or photo gallery
+        sourceType: srcType,
+        encodingType: Camera.EncodingType.JPEG,
+        mediaType: Camera.MediaType.PICTURE,
+        allowEdit: true,
+        correctOrientation: true  //Corrects Android orientation quirks
+    }
+    return options;
+}
+```
+
+Typically, you want to use a FILE_URI instead of a DATA_URL to avoid most memory issues. JPEG is the recommended encoding type for Android.
+
+You take a picture by passing in the options object to `getPicture`, which takes a CameraOptions object as the third argument. When you call `setOptions`, pass `Camera.PictureSourceType.CAMERA` as the picture source.
+
+```js
+function openCamera(selection) {
+
+    var srcType = Camera.PictureSourceType.CAMERA;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        displayImage(imageUri);
+        // You may choose to copy the picture, save it somewhere, or upload.
+        func(imageUri);
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+Once you take the picture, you can display it or do something else. In this example, call the app's `displayImage` function from the preceding code.
+
+```js
+function displayImage(imgUri) {
+
+    var elem = document.getElementById('imageFile');
+    elem.src = imgUri;
+}
+```
+
+To display the image on some platforms, you might need to include the main part of the URI in the Content-Security-Policy <meta> element in index.html. For example, on Windows 10, you can include `ms-appdata:` in your <meta> element. Here is an example.
+
+```html
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: ms-appdata: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">
+```
+
+## Take a Picture and Return Thumbnails (Resize the Picture) <a name="getThumbnails"></a>
+
+To get smaller images, you can return a resized image by passing both `targetHeight` and `targetWidth` values with your CameraOptions object. In this example, you resize the returned image to fit in a 100px by 100px box (the aspect ratio is maintained, so 100px is either the height or width, whichever is greater in the source).
+
+```js
+function openCamera(selection) {
+
+    var srcType = Camera.PictureSourceType.CAMERA;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    if (selection == "camera-thmb") {
+        options.targetHeight = 100;
+        options.targetWidth = 100;
+    }
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        // Do something
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+## Select a File from the Picture Library <a name="selectFile"></a>
+
+When selecting a file using the file picker, you also need to set the CameraOptions object. In this example, set the `sourceType` to `Camera.PictureSourceType.SAVEDPHOTOALBUM`. To open the file picker, call `getPicture` just as you did in the previous example, passing in the success and error callbacks along with CameraOptions object.
+
+```js
+function openFilePicker(selection) {
+
+    var srcType = Camera.PictureSourceType.SAVEDPHOTOALBUM;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        // Do something
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+## Select an Image and Return Thumbnails (resized images) <a name="getFileThumbnails"></a>
+
+Resizing a file selected with the file picker works just like resizing using the Camera app; set the `targetHeight` and `targetWidth` options.
+
+```js
+function openFilePicker(selection) {
+
+    var srcType = Camera.PictureSourceType.SAVEDPHOTOALBUM;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    if (selection == "picker-thmb") {
+        // To downscale a selected image,
+        // Camera.EncodingType (e.g., JPEG) must match the selected image type.
+        options.targetHeight = 100;
+        options.targetWidth = 100;
+    }
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        // Do something with image
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+## Take a picture and get a FileEntry Object <a name="convert"></a>
+
+If you want to do something like copy the image to another location, or upload it somewhere using the FileTransfer plugin, you need to get a FileEntry object for the returned picture. To do that, call `window.resolveLocalFileSystemURL` on the file URI returned by the Camera app. If you need to use a FileEntry object, set the `destinationType` to `Camera.DestinationType.FILE_URI` in your CameraOptions object (this is also the default value).
+
+>*Note* You need the [File plugin](https://www.npmjs.com/package/cordova-plugin-file) to call `window.resolveLocalFileSystemURL`.
+
+Here is the call to `window.resolveLocalFileSystemURL`. The image URI is passed to this function from the success callback of `getPicture`. The success handler of `resolveLocalFileSystemURL` receives the FileEntry object.
+
+```js
+function getFileEntry(imgUri) {
+    window.resolveLocalFileSystemURL(imgUri, function success(fileEntry) {
+
+        // Do something with the FileEntry object, like write to it, upload it, etc.
+        // writeFile(fileEntry, imgUri);
+        console.log("got file: " + fileEntry.fullPath);
+        // displayFileData(fileEntry.nativeURL, "Native URL");
+
+    }, function () {
+      // If don't get the FileEntry (which may happen when testing
+      // on some emulators), copy to a new FileEntry.
+        createNewFileEntry(imgUri);
+    });
+}
+```
+
+In the example shown in the preceding code, you call the app's `createNewFileEntry` function if you don't get a valid FileEntry object. The image URI returned from the Camera app should result in a valid FileEntry, but platform behavior on some emulators may be different for files returned from the file picker.
+
+>*Note* To see an example of writing to a FileEntry, see the [File plugin README](https://www.npmjs.com/package/cordova-plugin-file).
+
+The code shown here creates a file in your app's cache (in sandboxed storage) named `tempFile.jpeg`. With the new FileEntry object, you can copy the image to the file or do something else like upload it.
+
+```js
+function createNewFileEntry(imgUri) {
+    window.resolveLocalFileSystemURL(cordova.file.cacheDirectory, function success(dirEntry) {
+
+        // JPEG file
+        dirEntry.getFile("tempFile.jpeg", { create: true, exclusive: false }, function (fileEntry) {
+
+            // Do something with it, like write to it, upload it, etc.
+            // writeFile(fileEntry, imgUri);
+            console.log("got file: " + fileEntry.fullPath);
+            // displayFileData(fileEntry.fullPath, "File copied to");
+
+        }, onErrorCreateFile);
+
+    }, onErrorResolveUrl);
+}
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ description: Take pictures with the device camera.
 #         under the License.
 -->
 
-[![Build Status](https://travis-ci.org/apache/cordova-plugin-camera.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-camera)
+|Android|iOS| Windows 8.1 Store | Windows 8.1 Phone | Windows 10 Store | Travis CI |
+|:-:|:-:|:-:|:-:|:-:|:-:|
+|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=android,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=android,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=ios,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=ios,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=windows-8.1-store,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=windows-8.1-store,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=windows-8.1-phone,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=windows-8.1-phone,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=windows-10-store,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=windows-10-store,PLUGIN=cordova-plugin-camera/)|[![Build Status](https://travis-ci.org/apache/cordova-plugin-camera.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-camera)
 
 # cordova-plugin-camera
 
@@ -98,8 +100,10 @@ Documentation consists of template and API docs produced from the plugin JS code
 ---
 
 <a name="module_camera"></a>
+
 ## camera
 <a name="module_camera.getPicture"></a>
+
 ### camera.getPicture(successCallback, errorCallback, options)
 Takes a photo using the camera, or retrieves a photo from the device's
 image gallery.  The image is passed to the success callback as a
@@ -167,6 +171,7 @@ More examples [here](#camera-getPicture-examples). Quirks [here](#camera-getPict
 navigator.camera.getPicture(cameraSuccess, cameraError, cameraOptions);
 ```
 <a name="module_camera.cleanup"></a>
+
 ### camera.cleanup()
 Removes intermediate image files that are kept in temporary storage
 after calling [`camera.getPicture`](#module_camera.getPicture). Applies only when the value of
@@ -191,6 +196,7 @@ function onFail(message) {
 }
 ```
 <a name="module_camera.onError"></a>
+
 ### camera.onError : <code>function</code>
 Callback function that provides an error message.
 
@@ -201,6 +207,7 @@ Callback function that provides an error message.
 | message | <code>string</code> | The message is provided by the device's native code. |
 
 <a name="module_camera.onSuccess"></a>
+
 ### camera.onSuccess : <code>function</code>
 Callback function that provides the image data.
 
@@ -220,6 +227,7 @@ function cameraCallback(imageData) {
 }
 ```
 <a name="module_camera.CameraOptions"></a>
+
 ### camera.CameraOptions : <code>Object</code>
 Optional parameters to customize the camera settings.
 * [Quirks](#CameraOptions-quirks)
@@ -245,8 +253,10 @@ Optional parameters to customize the camera settings.
 ---
 
 <a name="module_Camera"></a>
+
 ## Camera
 <a name="module_Camera.DestinationType"></a>
+
 ### Camera.DestinationType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -258,6 +268,7 @@ Optional parameters to customize the camera settings.
 | NATIVE_URI | <code>number</code> | <code>2</code> | Return native uri (eg. asset-library://... for iOS) |
 
 <a name="module_Camera.EncodingType"></a>
+
 ### Camera.EncodingType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -268,6 +279,7 @@ Optional parameters to customize the camera settings.
 | PNG | <code>number</code> | <code>1</code> | Return PNG encoded image |
 
 <a name="module_Camera.MediaType"></a>
+
 ### Camera.MediaType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -279,6 +291,7 @@ Optional parameters to customize the camera settings.
 | ALLMEDIA | <code>number</code> | <code>2</code> | Allow selection from all media types |
 
 <a name="module_Camera.PictureSourceType"></a>
+
 ### Camera.PictureSourceType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -290,6 +303,7 @@ Optional parameters to customize the camera settings.
 | SAVEDPHOTOALBUM | <code>number</code> | <code>2</code> | Choose image from picture library (same as PHOTOLIBRARY for Android) |
 
 <a name="module_Camera.PopoverArrowDirection"></a>
+
 ### Camera.PopoverArrowDirection : <code>enum</code>
 Matches iOS UIPopoverArrowDirection constants to specify arrow location on popover.
 
@@ -305,6 +319,7 @@ Matches iOS UIPopoverArrowDirection constants to specify arrow location on popov
 | ARROW_ANY | <code>number</code> | <code>15</code> | 
 
 <a name="module_Camera.Direction"></a>
+
 ### Camera.Direction : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -317,6 +332,7 @@ Matches iOS UIPopoverArrowDirection constants to specify arrow location on popov
 ---
 
 <a name="module_CameraPopoverOptions"></a>
+
 ## CameraPopoverOptions
 iOS-only parameters that specify the anchor element location and arrow
 direction of the popover when selecting images from an iPad's library
@@ -338,6 +354,7 @@ location.
 ---
 
 <a name="module_CameraPopoverHandle"></a>
+
 ## CameraPopoverHandle
 A handle to an image picker popover.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+title: Camera
+description: Take pictures with the device camera.
+---
 <!---
 # license: Licensed to the Apache Software Foundation (ASF) under one
 #         or more contributor license agreements.  See the NOTICE file
@@ -73,20 +77,20 @@ Documentation consists of template and API docs produced from the plugin JS code
 
 
 * [camera](#module_camera)
-  * [.getPicture(successCallback, errorCallback, options)](#module_camera.getPicture)
-  * [.cleanup()](#module_camera.cleanup)
-  * [.onError](#module_camera.onError) : <code>function</code>
-  * [.onSuccess](#module_camera.onSuccess) : <code>function</code>
-  * [.CameraOptions](#module_camera.CameraOptions) : <code>Object</code>
+    * [.getPicture(successCallback, errorCallback, options)](#module_camera.getPicture)
+    * [.cleanup()](#module_camera.cleanup)
+    * [.onError](#module_camera.onError) : <code>function</code>
+    * [.onSuccess](#module_camera.onSuccess) : <code>function</code>
+    * [.CameraOptions](#module_camera.CameraOptions) : <code>Object</code>
 
 
 * [Camera](#module_Camera)
-  * [.DestinationType](#module_Camera.DestinationType) : <code>enum</code>
-  * [.EncodingType](#module_Camera.EncodingType) : <code>enum</code>
-  * [.MediaType](#module_Camera.MediaType) : <code>enum</code>
-  * [.PictureSourceType](#module_Camera.PictureSourceType) : <code>enum</code>
-  * [.PopoverArrowDirection](#module_Camera.PopoverArrowDirection) : <code>enum</code>
-  * [.Direction](#module_Camera.Direction) : <code>enum</code>
+    * [.DestinationType](#module_Camera.DestinationType) : <code>enum</code>
+    * [.EncodingType](#module_Camera.EncodingType) : <code>enum</code>
+    * [.MediaType](#module_Camera.MediaType) : <code>enum</code>
+    * [.PictureSourceType](#module_Camera.PictureSourceType) : <code>enum</code>
+    * [.PopoverArrowDirection](#module_Camera.PopoverArrowDirection) : <code>enum</code>
+    * [.Direction](#module_Camera.Direction) : <code>enum</code>
 
 * [CameraPopoverHandle](#module_CameraPopoverHandle)
 * [CameraPopoverOptions](#module_CameraPopoverOptions)
@@ -314,7 +318,13 @@ Matches iOS UIPopoverArrowDirection constants to specify arrow location on popov
 
 <a name="module_CameraPopoverOptions"></a>
 ## CameraPopoverOptions
-iOS-only parameters that specify the anchor element location and arrowdirection of the popover when selecting images from an iPad's libraryor album.Note that the size of the popover may change to adjust to thedirection of the arrow and orientation of the screen.  Make sure toaccount for orientation changes when specifying the anchor elementlocation.
+iOS-only parameters that specify the anchor element location and arrow
+direction of the popover when selecting images from an iPad's library
+or album.
+Note that the size of the popover may change to adjust to the
+direction of the arrow and orientation of the screen.  Make sure to
+account for orientation changes when specifying the anchor element
+location.
 
 
 | Param | Type | Default | Description |

--- a/README.md
+++ b/README.md
@@ -126,16 +126,13 @@ one of the following formats, depending on the specified
 `cameraOptions`:
 
 - A `String` containing the Base64-encoded photo image.
-
 - A `String` representing the image file location on local storage (default).
 
 You can do whatever you want with the encoded image or URI, for
 example:
 
 - Render the image in an `<img>` tag, as in the example below
-
 - Save the data locally (`LocalStorage`, [Lawnchair](http://brianleroux.github.com/lawnchair/), etc.)
-
 - Post the data to a remote server
 
 __NOTE__: Photo resolution on newer devices is quite good. Photos
@@ -258,6 +255,12 @@ Optional parameters to customize the camera settings.
 <a name="module_Camera.DestinationType"></a>
 
 ### Camera.DestinationType : <code>enum</code>
+Defines the output format of `Camera.getPicture` call.
+_Note:_ On iOS passing `DestinationType.NATIVE_URI` along with
+`PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM` will
+disable any image modifications (resize, quality change, cropping, etc.) due
+to implementation specific.
+
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
 
@@ -293,6 +296,11 @@ Optional parameters to customize the camera settings.
 <a name="module_Camera.PictureSourceType"></a>
 
 ### Camera.PictureSourceType : <code>enum</code>
+Defines the output format of `Camera.getPicture` call.
+_Note:_ On iOS passing `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM`
+along with `DestinationType.NATIVE_URI` will disable any image modifications (resize, quality
+change, cropping, etc.) due to implementation specific.
+
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
 
@@ -530,6 +538,8 @@ Tizen only supports a `destinationType` of
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
 
 - When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
+
+- When using `destinationType.NATIVE_URI` and `sourceType.PHOTOLIBRARY` or `sourceType.SAVEDPHOTOALBUM`, all editing options are ignored and link is returned to original picture.
 
 #### Tizen Quirks
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ Documentation consists of template and API docs produced from the plugin JS code
 ---
 
 <a name="module_camera"></a>
+
 ## camera
 <a name="module_camera.getPicture"></a>
+
 ### camera.getPicture(successCallback, errorCallback, options)
 Takes a photo using the camera, or retrieves a photo from the device's
 image gallery.  The image is passed to the success callback as a
@@ -167,6 +169,7 @@ More examples [here](#camera-getPicture-examples). Quirks [here](#camera-getPict
 navigator.camera.getPicture(cameraSuccess, cameraError, cameraOptions);
 ```
 <a name="module_camera.cleanup"></a>
+
 ### camera.cleanup()
 Removes intermediate image files that are kept in temporary storage
 after calling [`camera.getPicture`](#module_camera.getPicture). Applies only when the value of
@@ -191,6 +194,7 @@ function onFail(message) {
 }
 ```
 <a name="module_camera.onError"></a>
+
 ### camera.onError : <code>function</code>
 Callback function that provides an error message.
 
@@ -201,6 +205,7 @@ Callback function that provides an error message.
 | message | <code>string</code> | The message is provided by the device's native code. |
 
 <a name="module_camera.onSuccess"></a>
+
 ### camera.onSuccess : <code>function</code>
 Callback function that provides the image data.
 
@@ -220,6 +225,7 @@ function cameraCallback(imageData) {
 }
 ```
 <a name="module_camera.CameraOptions"></a>
+
 ### camera.CameraOptions : <code>Object</code>
 Optional parameters to customize the camera settings.
 * [Quirks](#CameraOptions-quirks)
@@ -245,8 +251,10 @@ Optional parameters to customize the camera settings.
 ---
 
 <a name="module_Camera"></a>
+
 ## Camera
 <a name="module_Camera.DestinationType"></a>
+
 ### Camera.DestinationType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -258,6 +266,7 @@ Optional parameters to customize the camera settings.
 | NATIVE_URI | <code>number</code> | <code>2</code> | Return native uri (eg. asset-library://... for iOS) |
 
 <a name="module_Camera.EncodingType"></a>
+
 ### Camera.EncodingType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -268,6 +277,7 @@ Optional parameters to customize the camera settings.
 | PNG | <code>number</code> | <code>1</code> | Return PNG encoded image |
 
 <a name="module_Camera.MediaType"></a>
+
 ### Camera.MediaType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -279,6 +289,7 @@ Optional parameters to customize the camera settings.
 | ALLMEDIA | <code>number</code> | <code>2</code> | Allow selection from all media types |
 
 <a name="module_Camera.PictureSourceType"></a>
+
 ### Camera.PictureSourceType : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -290,6 +301,7 @@ Optional parameters to customize the camera settings.
 | SAVEDPHOTOALBUM | <code>number</code> | <code>2</code> | Choose image from picture library (same as PHOTOLIBRARY for Android) |
 
 <a name="module_Camera.PopoverArrowDirection"></a>
+
 ### Camera.PopoverArrowDirection : <code>enum</code>
 Matches iOS UIPopoverArrowDirection constants to specify arrow location on popover.
 
@@ -305,6 +317,7 @@ Matches iOS UIPopoverArrowDirection constants to specify arrow location on popov
 | ARROW_ANY | <code>number</code> | <code>15</code> | 
 
 <a name="module_Camera.Direction"></a>
+
 ### Camera.Direction : <code>enum</code>
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -317,6 +330,7 @@ Matches iOS UIPopoverArrowDirection constants to specify arrow location on popov
 ---
 
 <a name="module_CameraPopoverOptions"></a>
+
 ## CameraPopoverOptions
 iOS-only parameters that specify the anchor element location and arrow
 direction of the popover when selecting images from an iPad's library
@@ -338,6 +352,7 @@ location.
 ---
 
 <a name="module_CameraPopoverHandle"></a>
+
 ## CameraPopoverHandle
 A handle to an image picker popover.
 

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -52,6 +52,8 @@ describe('Camera tests Android.', function () {
     var screenHeight = DEFAULT_SCREEN_HEIGHT;
     // promise count to use in promise ID
     var promiseCount = 0;
+    // going to set this to false if session is created successfully
+    var failedToStart = true;
 
     function getNextPromiseId() {
         promiseCount += 1;
@@ -127,10 +129,18 @@ describe('Camera tests Android.', function () {
                             .performTouchAction(tapTile);
                     }
                     return driver
+                        .waitForElementByXPath('//android.widget.TextView[@text="Gallery"]', 20000)
+                        .elementByXPath('//android.widget.TextView[@text="Gallery"]')
+                        .elementByXPath('//android.widget.TextView[@text="Gallery"]')
+                        .elementByXPath('//android.widget.TextView[@text="Gallery"]')
                         .elementByXPath('//android.widget.TextView[@text="Gallery"]')
                         .fail(function () {
                             return driver
                                 .performTouchAction(swipeRight)
+                                .waitForElementByXPath('//android.widget.TextView[@text="Gallery"]', 20000)
+                                .elementByXPath('//android.widget.TextView[@text="Gallery"]')
+                                .elementByXPath('//android.widget.TextView[@text="Gallery"]')
+                                .elementByXPath('//android.widget.TextView[@text="Gallery"]')
                                 .elementByXPath('//android.widget.TextView[@text="Gallery"]');
                         })
                         .click()
@@ -140,9 +150,13 @@ describe('Camera tests Android.', function () {
                 }
                 // taking a picture from camera
                 return driver
-                    .waitForElementByXPath('//android.widget.ImageView[contains(@resource-id,\'shutter\')]', MINUTE)
+                    .waitForElementByXPath('//android.widget.ImageView[contains(@resource-id,\'shutter\')]', MINUTE / 2)
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'shutter\')]')
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'shutter\')]')
                     .click()
-                    .waitForElementByXPath('//android.widget.ImageView[contains(@resource-id,\'done\')]', MINUTE)
+                    .waitForElementByXPath('//android.widget.ImageView[contains(@resource-id,\'done\')]', MINUTE / 2)
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'done\')]')
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'done\')]')
                     .click();
             })
             .then(function () {
@@ -168,7 +182,7 @@ describe('Camera tests Android.', function () {
         }
         return driver
             .context(webviewContext)
-            .setAsyncScriptTimeout(MINUTE)
+            .setAsyncScriptTimeout(MINUTE / 2)
             .executeAsync(cameraHelper.checkPicture, [getCurrentPromiseId(), options])
             .then(function (result) {
                 if (shouldLoad) {
@@ -253,13 +267,23 @@ describe('Camera tests Android.', function () {
         };
     }
 
+    function checkSession(done) {
+        if (failedToStart) {
+            fail('Failed to start a session');
+            done();
+        }
+    }
+
     it('camera.ui.util configuring driver and starting a session', function (done) {
         getDriver()
-            .fail(fail)
+            .then(function () {
+                failedToStart = false;
+            }, fail)
             .done(done);
     }, 5 * MINUTE);
 
     it('camera.ui.util determine screen dimensions', function (done) {
+        checkSession(done);
         return driver
             .context(webviewContext)
             .execute(function () {
@@ -278,6 +302,7 @@ describe('Camera tests Android.', function () {
     describe('Specs.', function () {
         // getPicture() with saveToPhotoLibrary = true
         it('camera.ui.spec.1 Saving a picture to the photo library', function (done) {
+            checkSession(done);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -294,6 +319,7 @@ describe('Camera tests Android.', function () {
 
         // getPicture() with mediaType: VIDEO, sourceType: PHOTOLIBRARY
         it('camera.ui.spec.2 Selecting only videos', function (done) {
+            checkSession(done);
             var spec = function () {
                 var options = { sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
                                 mediaType: cameraConstants.MediaType.VIDEO };
@@ -306,6 +332,8 @@ describe('Camera tests Android.', function () {
                         // try to find "Gallery" menu item
                         // if there's none, the gallery should be already opened
                         return driver
+                            .waitForElementByXPath('//android.widget.TextView[@text="Gallery"]', 20000)
+                            .elementByXPath('//android.widget.TextView[@text="Gallery"]')
                             .elementByXPath('//android.widget.TextView[@text="Gallery"]')
                             .then(function (element) {
                                 return element.click();
@@ -344,6 +372,7 @@ describe('Camera tests Android.', function () {
         // getPicture(), then dismiss
         // wait for the error callback to be called
         it('camera.ui.spec.3 Dismissing the camera', function (done) {
+            checkSession(done);
             var spec = function () {
                 var options = {
                     quality: 50,
@@ -357,6 +386,8 @@ describe('Camera tests Android.', function () {
                     })
                     .context("NATIVE_APP")
                     .waitForElementByXPath('//android.widget.ImageView[contains(@resource-id,\'cancel\')]', MINUTE / 2)
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'cancel\')]')
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'cancel\')]')
                     .click()
                     .then(function () {
                         return checkPicture(false);
@@ -369,6 +400,7 @@ describe('Camera tests Android.', function () {
         // getPicture(), then take picture but dismiss the edit
         // wait for the error callback to be called
         it('camera.ui.spec.4 Dismissing the edit', function (done) {
+            checkSession(done);
             var spec = function () {
                 var options = {
                     quality: 50,
@@ -382,10 +414,16 @@ describe('Camera tests Android.', function () {
                     })
                     .context('NATIVE_APP')
                     .waitForElementByXPath('//android.widget.ImageView[contains(@resource-id,\'shutter\')]', MINUTE / 2)
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'shutter\')]')
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'shutter\')]')
                     .click()
                     .waitForElementByXPath('//android.widget.ImageView[contains(@resource-id,\'done\')]', MINUTE / 2)
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'done\')]')
+                    .elementByXPath('//android.widget.ImageView[contains(@resource-id,\'done\')]')
                     .click()
                     .waitForElementByXPath('//*[contains(@resource-id,\'discard\')]', MINUTE / 2)
+                    .elementByXPath('//*[contains(@resource-id,\'discard\')]')
+                    .elementByXPath('//*[contains(@resource-id,\'discard\')]')
                     .click()
                     .then(function () {
                         return checkPicture(false);
@@ -396,6 +434,7 @@ describe('Camera tests Android.', function () {
         }, 10 * MINUTE);
 
         it('camera.ui.spec.5 Verifying target image size, sourceType=CAMERA', function (done) {
+            checkSession(done);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -409,6 +448,7 @@ describe('Camera tests Android.', function () {
         }, 10 * MINUTE);
 
         it('camera.ui.spec.6 Verifying target image size, sourceType=PHOTOLIBRARY', function (done) {
+            checkSession(done);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -422,6 +462,7 @@ describe('Camera tests Android.', function () {
         }, 10 * MINUTE);
 
         it('camera.ui.spec.7 Verifying target image size, sourceType=CAMERA, DestinationType=NATIVE_URI', function (done) {
+            checkSession(done);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -436,6 +477,7 @@ describe('Camera tests Android.', function () {
         }, 10 * MINUTE);
 
         it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, DestinationType=NATIVE_URI', function (done) {
+            checkSession(done);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -450,6 +492,7 @@ describe('Camera tests Android.', function () {
         }, 10 * MINUTE);
 
         it('camera.ui.spec.9 Verifying target image size, sourceType=CAMERA, DestinationType=NATIVE_URI, quality=100', function (done) {
+            checkSession(done);
             var spec = generateSpec({
                 quality: 100,
                 allowEdit: true,
@@ -464,6 +507,7 @@ describe('Camera tests Android.', function () {
         }, 10 * MINUTE);
 
         it('camera.ui.spec.10 Verifying target image size, sourceType=PHOTOLIBRARY, DestinationType=NATIVE_URI, quality=100', function (done) {
+            checkSession(done);
             var spec = generateSpec({
                 quality: 100,
                 allowEdit: true,
@@ -480,12 +524,14 @@ describe('Camera tests Android.', function () {
         // combine various options for getPicture()
         generateOptions().forEach(function (spec) {
             it('camera.ui.spec.11.' + spec.id + ' Combining options. ' + spec.description, function (done) {
+                checkSession(done);
                 var s = generateSpec(spec.options);
                 tryRunSpec(s).done(done);
             }, 10 * MINUTE);
         });
 
         it('camera.ui.util Delete test image from device library', function (done) {
+            checkSession(done);
             if (!isTestPictureSaved) {
                 // couldn't save test picture earlier, so nothing to delete here
                 done();
@@ -518,6 +564,7 @@ describe('Camera tests Android.', function () {
     });
 
     it('camera.ui.util Destroy the session', function (done) {
+        checkSession(done);
         driver
             .quit()
             .done(done);

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -118,12 +118,12 @@ describe('Camera tests Android.', function () {
                     tapTile
                         .tap({
                             x: Math.round(screenWidth / 4),
-                            y: Math.round(screenHeight / 5)
+                            y: Math.round(screenHeight / 4)
                         });
                     swipeRight
                         .press({x: 10, y: 100})
                         .wait(300)
-                        .moveTo({x: Math.round(screenWidth / 2), y: 0})
+                        .moveTo({x: Math.round(screenWidth - (screenWidth / 8)), y: 0})
                         .release()
                         .wait(1000);
                     if (options.allowEdit) {
@@ -306,8 +306,8 @@ describe('Camera tests Android.', function () {
             .context(webviewContext)
             .execute(function () {
                 return {
-                    'width': window.innerWidth,
-                    'height': window.innerHeight
+                    'width': screen.availWidth,
+                    'height': screen.availHeight
                 };
             }, [])
             .then(function (size) {
@@ -330,8 +330,10 @@ describe('Camera tests Android.', function () {
             })
             .then(function () {
                 cameraAvailable = true;
+            }, function () {
+                return recreateSession();
             })
-            .finally(done);
+            .done(done);
     }, 5 * MINUTE);
 
     describe('Specs.', function () {

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -299,7 +299,7 @@ describe('Camera tests Android.', function () {
                 appiumSessionStarted = true;
             }, fail)
             .done(done);
-    }, 5 * MINUTE);
+    }, 10 * MINUTE);
 
     it('camera.ui.util determine screen dimensions', function (done) {
         checkSession(done);

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -398,7 +398,9 @@ describe('Camera tests Android.', function () {
                             .then(function () {
                                 // success means we're still in native app
                                 return driver
-                                    .deviceKeyEvent(BACK_BUTTON);
+                                    .deviceKeyEvent(BACK_BUTTON)
+                                    // give native app some time to close
+                                    .sleep(2000);
                             }, function () {
                                 // error means we're already in webview
                                 return driver;

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -121,9 +121,10 @@ describe('Camera tests Android.', function () {
                             y: Math.round(screenHeight / 4)
                         });
                     swipeRight
-                        .press({x: 10, y: 100})
+                        .press({x: 10, y: 150})
                         .wait(300)
                         .moveTo({x: Math.round(screenWidth - (screenWidth / 8)), y: 0})
+                        .wait(1500)
                         .release()
                         .wait(1000);
                     if (options.allowEdit) {

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -292,6 +292,12 @@ describe('Camera tests Android.', function () {
         }
     }
 
+    function checkSauce(pending) {
+        if (global.USE_SAUCE) {
+            pending('This test cannot run on Sauce Labs yet. We\'re working on it!');
+        }
+    }
+
     it('camera.ui.util configuring driver and starting a session', function (done) {
         getDriver()
             .then(function () {
@@ -356,6 +362,7 @@ describe('Camera tests Android.', function () {
         // getPicture() with mediaType: VIDEO, sourceType: PHOTOLIBRARY
         it('camera.ui.spec.2 Selecting only videos', function (done) {
             checkSession(done);
+            checkSauce(pending);
             var spec = function () {
                 var options = { sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
                                 mediaType: cameraConstants.MediaType.VIDEO };
@@ -488,6 +495,7 @@ describe('Camera tests Android.', function () {
 
         it('camera.ui.spec.6 Verifying target image size, sourceType=PHOTOLIBRARY', function (done) {
             checkSession(done);
+            checkSauce(pending);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -518,6 +526,7 @@ describe('Camera tests Android.', function () {
 
         it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, DestinationType=NATIVE_URI', function (done) {
             checkSession(done);
+            checkSauce(pending);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -549,6 +558,7 @@ describe('Camera tests Android.', function () {
 
         it('camera.ui.spec.10 Verifying target image size, sourceType=PHOTOLIBRARY, DestinationType=NATIVE_URI, quality=100', function (done) {
             checkSession(done);
+            checkSauce(pending);
             var spec = generateSpec({
                 quality: 100,
                 allowEdit: true,
@@ -566,6 +576,7 @@ describe('Camera tests Android.', function () {
         generateOptions().forEach(function (spec) {
             it('camera.ui.spec.11.' + spec.id + ' Combining options. ' + spec.description, function (done) {
                 checkSession(done);
+                checkSauce(pending);
                 if (spec.options.sourceType == cameraConstants.PictureSourceType.CAMERA) {
                     checkCamera(pending);
                 }

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -292,12 +292,6 @@ describe('Camera tests Android.', function () {
         }
     }
 
-    function checkSauce(pending) {
-        if (global.USE_SAUCE) {
-            pending('This test cannot run on Sauce Labs yet. We\'re working on it!');
-        }
-    }
-
     it('camera.ui.util configuring driver and starting a session', function (done) {
         getDriver()
             .then(function () {
@@ -362,7 +356,6 @@ describe('Camera tests Android.', function () {
         // getPicture() with mediaType: VIDEO, sourceType: PHOTOLIBRARY
         it('camera.ui.spec.2 Selecting only videos', function (done) {
             checkSession(done);
-            checkSauce(pending);
             var spec = function () {
                 var options = { sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
                                 mediaType: cameraConstants.MediaType.VIDEO };
@@ -495,7 +488,6 @@ describe('Camera tests Android.', function () {
 
         it('camera.ui.spec.6 Verifying target image size, sourceType=PHOTOLIBRARY', function (done) {
             checkSession(done);
-            checkSauce(pending);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -526,7 +518,6 @@ describe('Camera tests Android.', function () {
 
         it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, DestinationType=NATIVE_URI', function (done) {
             checkSession(done);
-            checkSauce(pending);
             var spec = generateSpec({
                 quality: 50,
                 allowEdit: false,
@@ -558,7 +549,6 @@ describe('Camera tests Android.', function () {
 
         it('camera.ui.spec.10 Verifying target image size, sourceType=PHOTOLIBRARY, DestinationType=NATIVE_URI, quality=100', function (done) {
             checkSession(done);
-            checkSauce(pending);
             var spec = generateSpec({
                 quality: 100,
                 allowEdit: true,
@@ -576,7 +566,6 @@ describe('Camera tests Android.', function () {
         generateOptions().forEach(function (spec) {
             it('camera.ui.spec.11.' + spec.id + ' Combining options. ' + spec.description, function (done) {
                 checkSession(done);
-                checkSauce(pending);
                 if (spec.options.sourceType == cameraConstants.PictureSourceType.CAMERA) {
                     checkCamera(pending);
                 }

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -1,5 +1,5 @@
 /*jshint node: true, jasmine: true */
-/* global navigator, Q */
+
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -114,11 +114,23 @@ describe('Camera tests Android.', function () {
                         options.sourceType === cameraConstants.PictureSourceType.SAVEDPHOTOALBUM)) {
                     var tapTile = new wd.TouchAction();
                     var swipeRight = new wd.TouchAction();
-                    tapTile.tap({x: Math.round(screenWidth / 4), y: Math.round(screenHeight / 5)});
-                    swipeRight.press({x: 10, y: 100})
+                    tapTile
+                        .tap({
+                            x: Math.round(screenWidth / 4),
+                            y: Math.round(screenHeight / 5)
+                        });
+                    swipeRight
+                        .press({x: 10, y: 100})
                         .wait(300)
-                        .moveTo({x: Math.round(screenWidth / 2), y: 100})
-                        .release();
+                        .moveTo({x: Math.round(screenWidth / 2), y: 0})
+                        .release()
+                        .wait(1000);
+                    if (options.allowEdit) {
+                        return driver
+                            // always wait before performing touchAction
+                            .sleep(7000)
+                            .performTouchAction(tapTile);
+                    }
                     return driver
                         .elementByXPath('//android.widget.TextView[@text="Gallery"]')
                         .fail(function () {
@@ -126,17 +138,9 @@ describe('Camera tests Android.', function () {
                                 .performTouchAction(swipeRight)
                                 .elementByXPath('//android.widget.TextView[@text="Gallery"]');
                         })
-                        .then(function (element) {
-                            return element
-                                .click()
-                                // we need to sleep here to give a sidebar some time to close
-                                // if we don't sleep here, sometimes we would click on a sidebar
-                                // in the next step
-                                .sleep(3000);
-                        }, function () {
-                            // the gallery is already opened, just go on:
-                            return driver;
-                        })
+                        .click()
+                        // always wait before performing touchAction
+                        .sleep(7000)
                         .performTouchAction(tapTile);
                 }
                 // taking a picture from camera
@@ -156,7 +160,10 @@ describe('Camera tests Android.', function () {
                         .click();
                 }
             })
-            .fail(fail);
+            .fail(function (failure) {
+                console.log(failure);
+                fail(failure);
+            });
     }
 
     // checks if the picture was successfully taken
@@ -197,6 +204,8 @@ describe('Camera tests Android.', function () {
         var holdTile = new wd.TouchAction();
         holdTile.press({x: Math.round(screenWidth / 4), y: Math.round(screenHeight / 5)}).wait(1000).release();
         return driver
+            // always wait before performing touchAction
+            .sleep(7000)
             .performTouchAction(holdTile)
             .elementByXPath('//android.widget.TextView[@text="Delete"]')
             .then(function (element) {
@@ -407,5 +416,5 @@ describe('Camera tests Android.', function () {
         driver
             .quit()
             .done(done);
-    }, MINUTE);
+    }, 5 * MINUTE);
 });

--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -78,18 +78,13 @@ describe('Camera tests Android.', function () {
         var sourceTypes = [
                 cameraConstants.PictureSourceType.CAMERA,
                 cameraConstants.PictureSourceType.PHOTOLIBRARY
-            ],
-            destinationTypes = cameraConstants.DestinationType,
-            encodingTypes = [
-                cameraConstants.EncodingType.JPEG,
-                cameraConstants.EncodingType.PNG
-            ],
-            allowEditOptions = [
-                true,
-                false
             ];
+        var destinationTypes = cameraConstants.DestinationType;
+        var encodingTypes = cameraConstants.EncodingType;
+        var allowEditOptions = [ true, false ];
+        var correctOrientationOptions = [ true, false ];
 
-        return cameraHelper.generateSpecs(sourceTypes, destinationTypes, encodingTypes, allowEditOptions);
+        return cameraHelper.generateSpecs(sourceTypes, destinationTypes, encodingTypes, allowEditOptions, correctOrientationOptions);
     }
 
     // invokes Camera.getPicture() with the specified options
@@ -373,7 +368,7 @@ describe('Camera tests Android.', function () {
 
         // combine various options for getPicture()
         generateSpecs().forEach(function (spec) {
-            it('camera.ui.spec.5.' + spec.id + ' Combining options', function (done) {
+            it('camera.ui.spec.5.' + spec.id + ' Combining options. ' + spec.description, function (done) {
                 runCombinedSpec(spec)
                     .done(done);
             }, 3 * MINUTE);

--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -119,10 +119,19 @@ module.exports.checkPicture = function (pid, options, cb) {
     var isAndroid = cordova.platformId === "android";
     // skip image type check if it's unmodified on Android:
     // https://github.com/apache/cordova-plugin-camera/#android-quirks-1
-    var skipFileTypeCheck = isAndroid &&
-        options.quality === 100 &&
+    var skipFileTypeCheckAndroid = isAndroid && options.quality === 100 &&
         !options.targetWidth && !options.targetHeight &&
         !options.correctOrientation;
+
+    // Skip image type check if destination is NATIVE_URI and source - device's photoalbum
+    // https://github.com/apache/cordova-plugin-camera/#ios-quirks-1
+    // TODO: correct link above
+    var skipFileTypeCheckiOS = isIos && options.destinationType === Camera.DestinationType.NATIVE_URI &&
+        (options.sourceType === Camera.PictureSourceType.PHOTOLIBRARY ||
+         options.sourceType === Camera.PictureSourceType.SAVEDPHOTOALBUM);
+
+    var skipFileTypeCheck = skipFileTypeCheckAndroid || skipFileTypeCheckiOS;
+
     var desiredType = 'JPEG';
     var mimeType = 'image/jpeg';
     if (options.encodingType === Camera.EncodingType.PNG) {

--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -25,11 +25,35 @@
 
 var cameraConstants = require('../../www/CameraConstants');
 
-module.exports.generateSpecs = function (sourceTypes, destinationTypes, encodingTypes, allowEditOptions) {
+function findKeyByValue(set, value) {
+   for (var k in set) {
+      if (set.hasOwnProperty(k)) {
+         if (set[k] == value) {
+            return k;
+         }
+      }
+   }
+   return undefined;
+}
+
+function getDescription(spec) {
+    var desc = '';
+
+    desc += 'sourceType: ' + findKeyByValue(cameraConstants.PictureSourceType, spec.options.sourceType);
+    desc += ', destinationType: ' + findKeyByValue(cameraConstants.DestinationType, spec.options.destinationType);
+    desc += ', encodingType: ' + findKeyByValue(cameraConstants.EncodingType, spec.options.encodingType);
+    desc += ', allowEdit: ' + spec.options.allowEdit.toString();
+    desc += ', correctOrientation: ' + spec.options.correctOrientation.toString();
+
+    return desc;
+}
+
+module.exports.generateSpecs = function (sourceTypes, destinationTypes, encodingTypes, allowEditOptions, correctOrientationOptions) {
     var destinationType,
         sourceType,
         encodingType,
         allowEdit,
+        correctOrientation,
         specs = [],
         id = 1;
     for (destinationType in destinationTypes) {
@@ -40,9 +64,12 @@ module.exports.generateSpecs = function (sourceTypes, destinationTypes, encoding
                         if (encodingTypes.hasOwnProperty(encodingType)) {
                             for (allowEdit in allowEditOptions) {
                                 if (allowEditOptions.hasOwnProperty(allowEdit)) {
-                                    // if taking picture from photolibrary, don't vary 'correctOrientation' option
-                                    if (sourceTypes[sourceType] === cameraConstants.PictureSourceType.PHOTOLIBRARY) {
-                                        specs.push({
+                                    for (correctOrientation in correctOrientationOptions) {
+                                        // if taking picture from photolibrary, don't vary 'correctOrientation' option
+                                        if ((sourceTypes[sourceType] === cameraConstants.PictureSourceType.PHOTOLIBRARY ||
+                                            sourceTypes[sourceType] === cameraConstants.PictureSourceType.SAVEDPHOTOALBUM) &&
+                                            correctOrientation === true) { continue; }
+                                        var spec = {
                                             'id': id++,
                                             'options': {
                                                 'destinationType': destinationTypes[destinationType],
@@ -50,30 +77,11 @@ module.exports.generateSpecs = function (sourceTypes, destinationTypes, encoding
                                                 'encodingType': encodingTypes[encodingType],
                                                 'allowEdit': allowEditOptions[allowEdit],
                                                 'saveToPhotoAlbum': false,
+                                                'correctOrientation': correctOrientationOptions[correctOrientation]
                                             }
-                                        });
-                                    } else {
-                                        specs.push({
-                                            'id': id++,
-                                            'options': {
-                                                'destinationType': destinationTypes[destinationType],
-                                                'sourceType': sourceTypes[sourceType],
-                                                'encodingType': encodingTypes[encodingType],
-                                                'correctOrientation': true,
-                                                'allowEdit': allowEditOptions[allowEdit],
-                                                'saveToPhotoAlbum': false,
-                                            }
-                                        }, {
-                                            'id': id++,
-                                            'options': {
-                                                'destinationType': destinationTypes[destinationType],
-                                                'sourceType': sourceTypes[sourceType],
-                                                'encodingType': encodingTypes[encodingType],
-                                                'correctOrientation': false,
-                                                'allowEdit': allowEditOptions[allowEdit],
-                                                'saveToPhotoAlbum': false,
-                                            }
-                                        });
+                                        };
+                                        spec.description = getDescription(spec);
+                                        specs.push(spec);
                                     }
                                 }
                             }

--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -1,5 +1,5 @@
 /*jshint node: true */
-/* global Q */
+/* global Q, resolveLocalFileSystemURI, Camera, cordova */
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -94,7 +94,13 @@ module.exports.generateSpecs = function (sourceTypes, destinationTypes, encoding
     return specs;
 };
 
+// calls getPicture() and saves the result in promise
+// note that this function is executed in the context of tested app
+// and not in the context of tests
 module.exports.getPicture = function (opts, pid) {
+    if (navigator._appiumPromises[pid - 1]) {
+        navigator._appiumPromises[pid - 1] = null;
+    }
     navigator._appiumPromises[pid] = Q.defer();
     navigator.camera.getPicture(function (result) {
         navigator._appiumPromises[pid].resolve(result);
@@ -103,11 +109,185 @@ module.exports.getPicture = function (opts, pid) {
     }, opts);
 };
 
-module.exports.checkPicture = function (pid, cb) {
+// verifies taken picture when the promise is resolved,
+// calls a callback with 'OK' if everything is good,
+// calls a callback with 'ERROR: <error message>' if something is wrong
+// note that this function is executed in the context of tested app
+// and not in the context of tests
+module.exports.checkPicture = function (pid, options, cb) {
+    var isIos = cordova.platformId === "ios";
+    var isAndroid = cordova.platformId === "android";
+    // skip image type check if it's unmodified on Android:
+    // https://github.com/apache/cordova-plugin-camera/#android-quirks-1
+    var skipFileTypeCheck = isAndroid &&
+        options.quality === 100 &&
+        !options.targetWidth && !options.targetHeight &&
+        !options.correctOrientation;
+    var desiredType = 'JPEG';
+    var mimeType = 'image/jpeg';
+    if (options.encodingType === Camera.EncodingType.PNG) {
+        desiredType = 'PNG';
+        mimeType = 'image/png';
+    }
+
+    function errorCallback(msg) {
+        if (msg.hasOwnProperty('message')) {
+            msg = msg.message;
+        }
+        cb('ERROR: ' + msg);
+    }
+
+    // verifies the image we get from plugin
+    function verifyResult(result) {
+        if (result.length === 0) {
+            errorCallback('The result is empty.');
+            return;
+        } else if (isIos && options.destinationType === Camera.DestinationType.NATIVE_URI && result.indexOf('assets-library:') !== 0) {
+            errorCallback('Expected "' + result.substring(0, 150) + '"to start with "assets-library:"');
+            return;
+        } else if (isIos && options.destinationType === Camera.DestinationType.FILE_URI && result.indexOf('file:') !== 0) {
+            errorCallback('Expected "' + result.substring(0, 150) + '"to start with "file:"');
+            return;
+        }
+
+        try {
+            window.atob(result);
+            // if we got here it is a base64 string (DATA_URL)
+            result = "data:" + mimeType + ";base64," + result;
+        } catch (e) {
+            // not DATA_URL
+            if (options.destinationType === Camera.DestinationType.DATA_URL) {
+                errorCallback('Expected ' + result.substring(0, 150) + 'not to be DATA_URL');
+                return;
+            }
+        }
+        try {
+            if (result.indexOf('file:') === 0 ||
+                result.indexOf('content:') === 0 ||
+                result.indexOf('assets-library:') === 0) {
+
+                if (!window.resolveLocalFileSystemURI) {
+                    errorCallback('Cannot read file. Please install cordova-plugin-file to fix this.');
+                    return;
+                }
+                resolveLocalFileSystemURI(result, function (entry) {
+                    if (skipFileTypeCheck) {
+                        displayFile(entry);
+                    } else {
+                        verifyFile(entry);
+                    }
+                });
+            } else {
+                displayImage(result);
+            }
+        } catch (e) {
+            errorCallback(e);
+        }
+    }
+
+    // verifies that the file type matches the requested type
+    function verifyFile(entry) {
+        try {
+            var reader = new FileReader();
+            reader.onloadend = function(e) {
+                var arr = (new Uint8Array(e.target.result)).subarray(0, 4);
+                var header = '';
+                for(var i = 0; i < arr.length; i++) {
+                    header += arr[i].toString(16);
+                }
+                var actualType = 'unknown';
+
+                switch (header) {
+                    case "89504e47":
+                        actualType = 'PNG';
+                        break;
+                    case 'ffd8ffe0':
+                    case 'ffd8ffe1':
+                    case 'ffd8ffe2':
+                        actualType = 'JPEG';
+                        break;
+                }
+
+                if (actualType === desiredType) {
+                    displayFile(entry);
+                } else {
+                    errorCallback('File type mismatch. Expected ' + desiredType + ', got ' + actualType);
+                }
+            };
+            reader.onerror = function (e) {
+                errorCallback(e);
+            };
+            entry.file(function (file) {
+                reader.readAsArrayBuffer(file);
+            }, function (e) {
+                errorCallback(e);
+            });
+        } catch (e) {
+            errorCallback(e);
+        }
+    }
+
+    // reads the file, then displays the image
+    function displayFile(entry) {
+        function onFileReceived(file) {
+            var reader = new FileReader();
+            reader.onerror = function (e) {
+                errorCallback(e);
+            };
+            reader.onloadend = function (evt) {
+                displayImage(evt.target.result);
+            };
+            reader.readAsDataURL(file);
+        }
+
+        entry.file(onFileReceived, function (e) {
+            errorCallback(e);
+        });
+    }
+
+    function displayImage(image) {
+        try {
+            var imgEl = document.createElement('img');
+            document.body.appendChild(imgEl);
+            var timedOut = false;
+            var loadTimeout = setTimeout(function () {
+                timedOut = true;
+                document.body.removeChild(imgEl);
+                errorCallback('The image did not load: ' + image.substring(0, 150));
+            }, 10000);
+            var done = function (status) {
+                if (!timedOut) {
+                    clearTimeout(loadTimeout);
+                    document.body.removeChild(imgEl);
+                    cb(status);
+                }
+            };
+            imgEl.onload = function () {
+                try {
+                    // aspect ratio is preserved so only one dimension should match
+                    if ((typeof options.targetWidth === 'number' && imgEl.naturalWidth !== options.targetWidth) &&
+                        (typeof options.targetHeight === 'number' && imgEl.naturalHeight !== options.targetHeight))
+                    {
+                        done('ERROR: Wrong image size: ' + imgEl.naturalWidth + 'x' + imgEl.naturalHeight +
+                            '. Requested size: ' + options.targetWidth + 'x' + options.targetHeight);
+                    } else {
+                        done('OK');
+                    }
+                } catch (e) {
+                    errorCallback(e);
+                }
+            };
+            imgEl.src = image;
+        } catch (e) {
+            errorCallback(e);
+        }
+    }
+
     navigator._appiumPromises[pid].promise
         .then(function (result) {
-            cb(result);
-        }, function (err) {
-            cb('ERROR: ' + err);
+            verifyResult(result);
+        })
+        .fail(function (e) {
+            errorCallback(e);
         });
 };

--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -247,18 +247,22 @@ module.exports.checkPicture = function (pid, options, cb) {
 
     function displayImage(image) {
         try {
-            var imgEl = document.createElement('img');
-            document.body.appendChild(imgEl);
+            var imgEl = document.getElementById('camera_test_image');
+            if (!imgEl) {
+                imgEl = document.createElement('img');
+                imgEl.id = 'camera_test_image';
+                document.body.appendChild(imgEl);
+            }
             var timedOut = false;
             var loadTimeout = setTimeout(function () {
                 timedOut = true;
-                document.body.removeChild(imgEl);
+                imgEl.src = '';
                 errorCallback('The image did not load: ' + image.substring(0, 150));
             }, 10000);
             var done = function (status) {
                 if (!timedOut) {
                     clearTimeout(loadTimeout);
-                    document.body.removeChild(imgEl);
+                    imgEl.src = '';
                     cb(status);
                 }
             };

--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -125,7 +125,6 @@ module.exports.checkPicture = function (pid, options, cb) {
 
     // Skip image type check if destination is NATIVE_URI and source - device's photoalbum
     // https://github.com/apache/cordova-plugin-camera/#ios-quirks-1
-    // TODO: correct link above
     var skipFileTypeCheckiOS = isIos && options.destinationType === Camera.DestinationType.NATIVE_URI &&
         (options.sourceType === Camera.PictureSourceType.PHOTOLIBRARY ||
          options.sourceType === Camera.PictureSourceType.SAVEDPHOTOALBUM);

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -67,21 +67,13 @@ describe('Camera tests iOS.', function () {
     // generates test specs by combining all the specified options
     // you can add more options to test more scenarios
     function generateSpecs() {
-        var sourceTypes = [
-                cameraConstants.PictureSourceType.CAMERA,
-                cameraConstants.PictureSourceType.PHOTOLIBRARY
-            ],
-            destinationTypes = cameraConstants.DestinationType,
-            encodingTypes = [
-                cameraConstants.EncodingType.JPEG,
-                cameraConstants.EncodingType.PNG
-            ],
-            allowEditOptions = [
-                true,
-                false
-            ];
+        var sourceTypes = cameraConstants.PictureSourceType;
+        var destinationTypes = cameraConstants.DestinationType;
+        var encodingTypes = cameraConstants.EncodingType;
+        var allowEditOptions = [ true, false ];
+        var correctOrientationOptions = [ true, false ];
 
-        return cameraHelper.generateSpecs(sourceTypes, destinationTypes, encodingTypes, allowEditOptions);
+        return cameraHelper.generateSpecs(sourceTypes, destinationTypes, encodingTypes, allowEditOptions, correctOrientationOptions);
     }
 
     function usePicture() {
@@ -245,7 +237,7 @@ describe('Camera tests iOS.', function () {
 
         // combine various options for getPicture()
         generateSpecs().forEach(function (spec) {
-            it('camera.ui.spec.3.' + spec.id + ' Combining options', function (done) {
+            it('camera.ui.spec.3.' + spec.id + ' Combining options. ' + spec.description, function (done) {
                 // camera is not available on iOS simulator
                 if (!isDevice && spec.options.sourceType === cameraConstants.PictureSourceType.CAMERA) {
                     pending();

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -203,7 +203,7 @@ describe('Camera tests iOS.', function () {
                 failedToStart = false;
             }, fail)
             .done(done);
-    }, 5 * MINUTE);
+    }, 10 * MINUTE);
 
     describe('Specs.', function () {
         // getPicture() with mediaType: VIDEO, sourceType: PHOTOLIBRARY

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -286,7 +286,7 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.6 Verifying target image size, sourceType=CAMERA, destinationType=NATIVE_URI', function (done) {
+        it('camera.ui.spec.6 Verifying target image size, sourceType=CAMERA, destinationType=FILE_URL', function (done) {
             // remove this line if you don't mind the tests leaving a photo saved on device
             pending('Cannot prevent iOS from saving the picture to photo library');
 
@@ -298,7 +298,7 @@ describe('Camera tests iOS.', function () {
                 quality: 50,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.CAMERA,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 210,
                 targetHeight: 210
@@ -307,13 +307,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.7 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=NATIVE_URI', function (done) {
+        it('camera.ui.spec.7 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=FILE_URL', function (done) {
             checkSession(done);
             var options = {
                 quality: 50,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 210,
                 targetHeight: 210
@@ -322,13 +322,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=NATIVE_URI', function (done) {
+        it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=FILE_URL', function (done) {
             checkSession(done);
             var options = {
                 quality: 50,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 210,
                 targetHeight: 210
@@ -337,7 +337,7 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.9 Verifying target image size, sourceType=CAMERA, destinationType=NATIVE_URI, quality=100', function (done) {
+        it('camera.ui.spec.9 Verifying target image size, sourceType=CAMERA, destinationType=FILE_URL, quality=100', function (done) {
             // remove this line if you don't mind the tests leaving a photo saved on device
             pending('Cannot prevent iOS from saving the picture to photo library');
 
@@ -349,7 +349,7 @@ describe('Camera tests iOS.', function () {
                 quality: 100,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.CAMERA,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 305,
                 targetHeight: 305
@@ -357,13 +357,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.10 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=NATIVE_URI, quality=100', function (done) {
+        it('camera.ui.spec.10 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=FILE_URL, quality=100', function (done) {
             checkSession(done);
             var options = {
                 quality: 100,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 305,
                 targetHeight: 305
@@ -372,13 +372,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.11 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=NATIVE_URI, quality=100', function (done) {
+        it('camera.ui.spec.11 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=FILE_URL, quality=100', function (done) {
             checkSession(done);
             var options = {
                 quality: 100,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 305,
                 targetHeight: 305

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -81,17 +81,8 @@ describe('Camera tests iOS.', function () {
             .elementByXPath('//*[@label="Use"]')
             .click()
             .fail(function () {
-                return driver
-                    // For some reason "Choose" element is not clickable by standard Appium methods
-                    // So getting its position and tapping there using TouchAction
-                    .elementByXPath('//UIAButton[@label="Choose"]')
-                    .getLocation()
-                    .then(function (loc) {
-                        var tapChoose = new wd.TouchAction();
-                        tapChoose.tap(loc);
-                        return driver
-                            .performTouchAction(tapChoose);
-                    });
+                // For some reason "Choose" element is not clickable by standard Appium methods
+                return wdHelper.tapElementByXPath('//UIAButton[@label="Choose"]', driver);
             });
     }
 

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -1,5 +1,5 @@
 /*jshint node: true, jasmine: true */
-/* global navigator, Q */
+
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -260,5 +260,5 @@ describe('Camera tests iOS.', function () {
         driver
             .quit()
             .done(done);
-    }, MINUTE);
+    }, 5 * MINUTE);
 });

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -66,7 +66,7 @@ describe('Camera tests iOS.', function () {
 
     // generates test specs by combining all the specified options
     // you can add more options to test more scenarios
-    function generateSpecs() {
+    function generateOptions() {
         var sourceTypes = cameraConstants.PictureSourceType;
         var destinationTypes = cameraConstants.DestinationType;
         var encodingTypes = cameraConstants.EncodingType;
@@ -149,33 +149,34 @@ describe('Camera tests iOS.', function () {
 
     // checks if the picture was successfully taken
     // if shouldLoad is falsy, ensures that the error callback was called
-    function checkPicture(shouldLoad) {
+    function checkPicture(shouldLoad, options) {
+        if (!options) {
+            options = {};
+        }
         return driver
             .context(webviewContext)
             .setAsyncScriptTimeout(MINUTE)
-            .executeAsync(cameraHelper.checkPicture, [getCurrentPromiseId()])
+            .executeAsync(cameraHelper.checkPicture, [getCurrentPromiseId(), options])
             .then(function (result) {
                 if (shouldLoad) {
-                    expect(result.length).toBeGreaterThan(0);
-                    if (result.indexOf('ERROR') >= 0) {
-                        return fail(result);
+                    if (result !== 'OK') {
+                        fail(result);
                     }
-                } else {
-                    if (result.indexOf('ERROR') === -1) {
-                        return fail('Unexpected success callback with result: ' + result);
-                    }
-                    expect(result.indexOf('ERROR')).toBe(0);
+                } else if (result.indexOf('ERROR') === -1) {
+                    throw 'Unexpected success callback with result: ' + result;
                 }
             });
     }
 
-    function runCombinedSpec(spec) {
+    // takes a picture with the specified options
+    // and then verifies it
+    function runSpec(options) {
         return driver
             .then(function () {
-                return getPicture(spec.options);
+                return getPicture(options);
             })
             .then(function () {
-                return checkPicture(true);
+                return checkPicture(true, options);
             })
             .fail(saveScreenshotAndFail);
     }
@@ -219,9 +220,8 @@ describe('Camera tests iOS.', function () {
         // getPicture(), then dismiss
         // wait for the error callback to be called
         it('camera.ui.spec.2 Dismissing the camera', function (done) {
-            // camera is not available on the iOS simulator
             if (!isDevice) {
-                pending();
+                pending('Camera is not available on iOS simulator');
             }
             var options = { sourceType: cameraConstants.PictureSourceType.CAMERA };
             driver
@@ -235,20 +235,156 @@ describe('Camera tests iOS.', function () {
                 .done(done);
         }, 3 * MINUTE);
 
+        it('camera.ui.spec.3 Verifying target image size, sourceType=CAMERA', function (done) {
+            if (!isDevice) {
+                pending('Camera is not available on iOS simulator');
+            }
+            var options = {
+                quality: 50,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.CAMERA,
+                saveToPhotoAlbum: false,
+                targetWidth: 210,
+                targetHeight: 210
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.4 Verifying target image size, sourceType=SAVEDPHOTOALBUM', function (done) {
+            var options = {
+                quality: 50,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
+                saveToPhotoAlbum: false,
+                targetWidth: 210,
+                targetHeight: 210
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.5 Verifying target image size, sourceType=PHOTOLIBRARY', function (done) {
+            var options = {
+                quality: 50,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
+                saveToPhotoAlbum: false,
+                targetWidth: 210,
+                targetHeight: 210
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.6 Verifying target image size, sourceType=CAMERA, destinationType=NATIVE_URI', function (done) {
+            if (!isDevice) {
+                pending('Camera is not available on iOS simulator');
+            }
+            var options = {
+                quality: 50,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.CAMERA,
+                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                saveToPhotoAlbum: false,
+                targetWidth: 210,
+                targetHeight: 210
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.7 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=NATIVE_URI', function (done) {
+            var options = {
+                quality: 50,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
+                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                saveToPhotoAlbum: false,
+                targetWidth: 210,
+                targetHeight: 210
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=NATIVE_URI', function (done) {
+            var options = {
+                quality: 50,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
+                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                saveToPhotoAlbum: false,
+                targetWidth: 210,
+                targetHeight: 210
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.9 Verifying target image size, sourceType=CAMERA, destinationType=NATIVE_URI, quality=100', function (done) {
+            if (!isDevice) {
+                pending('Camera is not available on iOS simulator');
+            }
+            var options = {
+                quality: 100,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.CAMERA,
+                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                saveToPhotoAlbum: false,
+                targetWidth: 305,
+                targetHeight: 305
+            };
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.10 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=NATIVE_URI, quality=100', function (done) {
+            var options = {
+                quality: 100,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
+                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                saveToPhotoAlbum: false,
+                targetWidth: 305,
+                targetHeight: 305
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
+        it('camera.ui.spec.11 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=NATIVE_URI, quality=100', function (done) {
+            var options = {
+                quality: 100,
+                allowEdit: false,
+                sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
+                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                saveToPhotoAlbum: false,
+                targetWidth: 305,
+                targetHeight: 305
+            };
+
+            runSpec(options).done(done);
+        }, 3 * MINUTE);
+
         // combine various options for getPicture()
-        generateSpecs().forEach(function (spec) {
-            it('camera.ui.spec.3.' + spec.id + ' Combining options. ' + spec.description, function (done) {
-                // camera is not available on iOS simulator
+        generateOptions().forEach(function (spec) {
+            it('camera.ui.spec.12.' + spec.id + ' Combining options. ' + spec.description, function (done) {
                 if (!isDevice && spec.options.sourceType === cameraConstants.PictureSourceType.CAMERA) {
-                    pending();
+                    pending('Camera is not available on iOS simulator');
                 }
-                runCombinedSpec(spec).done(done);
+                if (spec.options.sourceType === cameraConstants.PictureSourceType.CAMERA &&
+                    spec.options.destinationType === cameraConstants.DestinationType.NATIVE_URI) {
+                    pending('Skipping: cannot prevent iOS from saving the picture to photo library and cannot delete it. ' +
+                        'For more info, see iOS quirks here: https://github.com/apache/cordova-plugin-camera#ios-quirks-1');
+                }
+
+                runSpec(spec.options).done(done);
             }, 3 * MINUTE);
         });
 
     });
 
-    it('camera.ui.util.4 Destroy the session', function (done) {
+    it('camera.ui.util Destroy the session', function (done) {
         driver
             .quit()
             .done(done);

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -1,3 +1,7 @@
+---
+title: Camera
+description: Take pictures with the device camera.
+---
 {{>cdv-license~}}
 
 [![Build Status](https://travis-ci.org/apache/cordova-plugin-camera.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-camera)

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -4,7 +4,9 @@ description: Take pictures with the device camera.
 ---
 {{>cdv-license~}}
 
-[![Build Status](https://travis-ci.org/apache/cordova-plugin-camera.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-camera)
+|Android|iOS| Windows 8.1 Store | Windows 8.1 Phone | Windows 10 Store | Travis CI |
+|:-:|:-:|:-:|:-:|:-:|:-:|
+|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=android,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=android,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=ios,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=ios,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=windows-8.1-store,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=windows-8.1-store,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=windows-8.1-phone,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=windows-8.1-phone,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=windows-10-store,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=windows-10-store,PLUGIN=cordova-plugin-camera/)|[![Build Status](https://travis-ci.org/apache/cordova-plugin-camera.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-camera)
 
 # cordova-plugin-camera
 

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -203,3 +203,202 @@ Tizen only supports a `destinationType` of
 [web_activities]: https://hacks.mozilla.org/2013/01/introducing-web-activities/
 [wp8_bug]: https://issues.apache.org/jira/browse/CB-2083
 [msdn_wp8_docs]: http://msdn.microsoft.com/en-us/library/windowsphone/develop/hh394006.aspx
+
+## Sample: Take Pictures, Select Pictures from the Picture Library, and Get Thumbnails <a name="sample"></a>
+
+The Camera plugin allows you to do things like open the device's Camera app and take a picture, or open the file picker and select one. The code snippets in this section demonstrate different tasks including:
+
+* Open the Camera app and [take a Picture](#takePicture)
+* Take a picture and [return thumbnails](#getThumbnails) (resized picture)
+* Take a picture and [generate a FileEntry object](#convert)
+* [Select a file](#selectFile) from the picture library
+* Select a JPEG image and [return thumbnails](#getFileThumbnails) (resized image)
+* Select an image and [generate a FileEntry object](#convert)
+
+## Take a Picture <a name="takePicture"></a>
+
+Before you can take a picture, you need to set some Camera plugin options to pass into the Camera plugin's `getPicture` function. Here is a common set of recommendations. In this example, you create the object that you will use for the Camera options, and set the `sourceType` dynamically to support both the Camera app and the file picker.
+
+```js
+function setOptions(srcType) {
+    var options = {
+        // Some common settings are 20, 50, and 100
+        quality: 50,
+        destinationType: Camera.DestinationType.FILE_URI,
+        // In this app, dynamically set the picture source, Camera or photo gallery
+        sourceType: srcType,
+        encodingType: Camera.EncodingType.JPEG,
+        mediaType: Camera.MediaType.PICTURE,
+        allowEdit: true,
+        correctOrientation: true  //Corrects Android orientation quirks
+    }
+    return options;
+}
+```
+
+Typically, you want to use a FILE_URI instead of a DATA_URL to avoid most memory issues. JPEG is the recommended encoding type for Android.
+
+You take a picture by passing in the options object to `getPicture`, which takes a CameraOptions object as the third argument. When you call `setOptions`, pass `Camera.PictureSourceType.CAMERA` as the picture source.
+
+```js
+function openCamera(selection) {
+
+    var srcType = Camera.PictureSourceType.CAMERA;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        displayImage(imageUri);
+        // You may choose to copy the picture, save it somewhere, or upload.
+        func(imageUri);
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+Once you take the picture, you can display it or do something else. In this example, call the app's `displayImage` function from the preceding code.
+
+```js
+function displayImage(imgUri) {
+
+    var elem = document.getElementById('imageFile');
+    elem.src = imgUri;
+}
+```
+
+To display the image on some platforms, you might need to include the main part of the URI in the Content-Security-Policy <meta> element in index.html. For example, on Windows 10, you can include `ms-appdata:` in your <meta> element. Here is an example.
+
+```html
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: ms-appdata: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">
+```
+
+## Take a Picture and Return Thumbnails (Resize the Picture) <a name="getThumbnails"></a>
+
+To get smaller images, you can return a resized image by passing both `targetHeight` and `targetWidth` values with your CameraOptions object. In this example, you resize the returned image to fit in a 100px by 100px box (the aspect ratio is maintained, so 100px is either the height or width, whichever is greater in the source).
+
+```js
+function openCamera(selection) {
+
+    var srcType = Camera.PictureSourceType.CAMERA;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    if (selection == "camera-thmb") {
+        options.targetHeight = 100;
+        options.targetWidth = 100;
+    }
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        // Do something
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+## Select a File from the Picture Library <a name="selectFile"></a>
+
+When selecting a file using the file picker, you also need to set the CameraOptions object. In this example, set the `sourceType` to `Camera.PictureSourceType.SAVEDPHOTOALBUM`. To open the file picker, call `getPicture` just as you did in the previous example, passing in the success and error callbacks along with CameraOptions object.
+
+```js
+function openFilePicker(selection) {
+
+    var srcType = Camera.PictureSourceType.SAVEDPHOTOALBUM;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        // Do something
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+## Select an Image and Return Thumbnails (resized images) <a name="getFileThumbnails"></a>
+
+Resizing a file selected with the file picker works just like resizing using the Camera app; set the `targetHeight` and `targetWidth` options.
+
+```js
+function openFilePicker(selection) {
+
+    var srcType = Camera.PictureSourceType.SAVEDPHOTOALBUM;
+    var options = setOptions(srcType);
+    var func = createNewFileEntry;
+
+    if (selection == "picker-thmb") {
+        // To downscale a selected image,
+        // Camera.EncodingType (e.g., JPEG) must match the selected image type.
+        options.targetHeight = 100;
+        options.targetWidth = 100;
+    }
+
+    navigator.camera.getPicture(function cameraSuccess(imageUri) {
+
+        // Do something with image
+
+    }, function cameraError(error) {
+        console.debug("Unable to obtain picture: " + error, "app");
+
+    }, options);
+}
+```
+
+## Take a picture and get a FileEntry Object <a name="convert"></a>
+
+If you want to do something like copy the image to another location, or upload it somewhere using the FileTransfer plugin, you need to get a FileEntry object for the returned picture. To do that, call `window.resolveLocalFileSystemURL` on the file URI returned by the Camera app. If you need to use a FileEntry object, set the `destinationType` to `Camera.DestinationType.FILE_URI` in your CameraOptions object (this is also the default value).
+
+>*Note* You need the [File plugin](https://www.npmjs.com/package/cordova-plugin-file) to call `window.resolveLocalFileSystemURL`.
+
+Here is the call to `window.resolveLocalFileSystemURL`. The image URI is passed to this function from the success callback of `getPicture`. The success handler of `resolveLocalFileSystemURL` receives the FileEntry object.
+
+```js
+function getFileEntry(imgUri) {
+    window.resolveLocalFileSystemURL(imgUri, function success(fileEntry) {
+
+        // Do something with the FileEntry object, like write to it, upload it, etc.
+        // writeFile(fileEntry, imgUri);
+        console.log("got file: " + fileEntry.fullPath);
+        // displayFileData(fileEntry.nativeURL, "Native URL");
+
+    }, function () {
+      // If don't get the FileEntry (which may happen when testing
+      // on some emulators), copy to a new FileEntry.
+        createNewFileEntry(imgUri);
+    });
+}
+```
+
+In the example shown in the preceding code, you call the app's `createNewFileEntry` function if you don't get a valid FileEntry object. The image URI returned from the Camera app should result in a valid FileEntry, but platform behavior on some emulators may be different for files returned from the file picker.
+
+>*Note* To see an example of writing to a FileEntry, see the [File plugin README](https://www.npmjs.com/package/cordova-plugin-file).
+
+The code shown here creates a file in your app's cache (in sandboxed storage) named `tempFile.jpeg`. With the new FileEntry object, you can copy the image to the file or do something else like upload it.
+
+```js
+function createNewFileEntry(imgUri) {
+    window.resolveLocalFileSystemURL(cordova.file.cacheDirectory, function success(dirEntry) {
+
+        // JPEG file
+        dirEntry.getFile("tempFile.jpeg", { create: true, exclusive: false }, function (fileEntry) {
+
+            // Do something with it, like write to it, upload it, etc.
+            // writeFile(fileEntry, imgUri);
+            console.log("got file: " + fileEntry.fullPath);
+            // displayFileData(fileEntry.fullPath, "File copied to");
+
+        }, onErrorCreateFile);
+
+    }, onErrorResolveUrl);
+}
+```

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -15,7 +15,7 @@ the system's image library.
 
 ---
 
-# API Reference
+# API Reference <a name="reference"></a>
 
 {{#orphans~}}
 {{>member-index}}
@@ -274,7 +274,7 @@ function displayImage(imgUri) {
 }
 ```
 
-To display the image on some platforms, you might need to include the main part of the URI in the Content-Security-Policy <meta> element in index.html. For example, on Windows 10, you can include `ms-appdata:` in your <meta> element. Here is an example.
+To display the image on some platforms, you might need to include the main part of the URI in the Content-Security-Policy `<meta>` element in index.html. For example, on Windows 10, you can include `ms-appdata:` in your `<meta>` element. Here is an example.
 
 ```html
 <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: ms-appdata: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -187,6 +187,8 @@ Tizen only supports a `destinationType` of
 
 - When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
 
+- When using `destinationType.NATIVE_URI` and `sourceType.PHOTOLIBRARY` or `sourceType.SAVEDPHOTOALBUM`, all editing options are ignored and link is returned to original picture.
+
 #### Tizen Quirks
 
 - options not supported

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "cordova-browser",
     "cordova-windows"
   ],
-  "peerDependencies": {
-    "cordova-plugin-file": ">=2.0.0"
-  },
   "scripts": {
     "precommit": "npm run gen-docs && git add README.md",
     "gen-docs": "jsdoc2md --template \"jsdoc2md/TEMPLATE.md\" \"www/**/*.js\" --plugin \"dmd-plugin-cordova-plugin\" > README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "2.2.0",
+  "version": "2.2.1-dev",
   "description": "Cordova Camera Plugin",
   "cordova": {
     "id": "cordova-plugin-camera",

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-camera"
-    version="2.2.0">
+    version="2.2.1-dev">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -365,7 +365,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     intent.putExtra("aspectX", 1);
                     intent.putExtra("aspectY", 1);
                 }
-                File photo = createCaptureFile(encodingType);
+                File photo = createCaptureFile(JPEG);
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
             } else {
@@ -592,15 +592,29 @@ private void refreshGallery(Uri contentUri)
     this.cordova.getActivity().sendBroadcast(mediaScanIntent);
 }
 
+    /**
+     * Converts output image format int value to string value of mime type.
+     * @param outputFormat int Output format of camera API.
+     *                     Must be value of either JPEG or PNG constant
+     * @return String String value of mime type or empty string if mime type is not supported
+     */
+    private String getMimetypeForFormat(int outputFormat) {
+        if (outputFormat == PNG) return "image/png";
+        if (outputFormat == JPEG) return "image/jpeg";
+        return "";
+    }
 
-private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
+    private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         // Some content: URIs do not map to file paths (e.g. picasa).
         String realPath = FileHelper.getRealPath(uri, this.cordova);
 
         // Get filename from uri
         String fileName = realPath != null ?
-            realPath.substring(realPath.lastIndexOf('/') + 1) :
-            "modified." + (this.encodingType == JPEG ? "jpg" : "png");
+            realPath.substring(realPath.lastIndexOf('/') + 1, realPath.lastIndexOf(".") + 1) :
+            "modified.";
+
+        // Append filename extension based on output encoding type
+        fileName += (this.encodingType == JPEG ? "jpg" : "png");
 
         String modifiedPath = getTempDirectoryPath() + "/" + fileName;
 
@@ -660,15 +674,18 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
             this.callbackContext.success(fileLocation);
         }
         else {
+            String uriString = uri.toString();
+            // Get the path to the image. Makes loading so much easier.
+            String mimeType = FileHelper.getMimeType(uriString, this.cordova);
+
             // This is a special case to just return the path as no scaling,
             // rotating, nor compressing needs to be done
             if (this.targetHeight == -1 && this.targetWidth == -1 &&
-                    (destType == FILE_URI || destType == NATIVE_URI) && !this.correctOrientation) {
-                this.callbackContext.success(uri.toString());
+                    (destType == FILE_URI || destType == NATIVE_URI) && !this.correctOrientation &&
+                    mimeType.equalsIgnoreCase(getMimetypeForFormat(encodingType)))
+            {
+                this.callbackContext.success(uriString);
             } else {
-                String uriString = uri.toString();
-                // Get the path to the image. Makes loading so much easier.
-                String mimeType = FileHelper.getMimeType(uriString, this.cordova);
                 // If we don't have a valid image so quit.
                 if (!("image/jpeg".equalsIgnoreCase(mimeType) || "image/png".equalsIgnoreCase(mimeType))) {
                     Log.d(LOG_TAG, "I either have a null image path or bitmap");
@@ -710,7 +727,9 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
                 else if (destType == FILE_URI || destType == NATIVE_URI) {
                     // Did we modify the image?
                     if ( (this.targetHeight > 0 && this.targetWidth > 0) ||
-                            (this.correctOrientation && this.orientationCorrected) ) {
+                            (this.correctOrientation && this.orientationCorrected) ||
+                            !mimeType.equalsIgnoreCase(getMimetypeForFormat(encodingType)))
+                    {
                         try {
                             String modifiedPath = this.ouputModifiedBitmap(bitmap, uri);
                             // The modified image is cached by the app in order to get around this and not have to delete you

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -138,7 +138,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             this.targetWidth = 0;
             this.encodingType = JPEG;
             this.mediaType = PICTURE;
-            this.mQuality = 80;
+            this.mQuality = 50;
 
             //Take the values from the arguments if they're not already defined (this is tricky)
             this.destType = args.getInt(1);

--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -28,6 +28,7 @@ function takePicture(success, error, opts) {
         var input = document.createElement('input');
         input.style.position = 'relative';
         input.style.zIndex = HIGHEST_POSSIBLE_Z_INDEX;
+        input.className = 'cordova-camera-select';
         input.type = 'file';
         input.name = 'files[]';
 
@@ -61,6 +62,7 @@ function capture(success, errorCallback, opts) {
     var parent = document.createElement('div');
     parent.style.position = 'relative';
     parent.style.zIndex = HIGHEST_POSSIBLE_Z_INDEX;
+    parent.className = 'cordova-camera-capture';
     parent.appendChild(video);
     parent.appendChild(button);
 

--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -23,7 +23,7 @@ var HIGHEST_POSSIBLE_Z_INDEX = 2147483647;
 
 function takePicture(success, error, opts) {
     if (opts && opts[2] === 1) {
-        capture(success, error);
+        capture(success, error, opts);
     } else {
         var input = document.createElement('input');
         input.style.position = 'relative';
@@ -48,8 +48,13 @@ function takePicture(success, error, opts) {
     }
 }
 
-function capture(success, errorCallback) {
+function capture(success, errorCallback, opts) {
     var localMediaStream;
+    var targetWidth = opts[3];
+    var targetHeight = opts[4];
+
+    targetWidth = targetWidth == -1?320:targetWidth;
+    targetHeight = targetHeight == -1?240:targetHeight;
 
     var video = document.createElement('video');
     var button = document.createElement('button');
@@ -59,14 +64,16 @@ function capture(success, errorCallback) {
     parent.appendChild(video);
     parent.appendChild(button);
 
-    video.width = 320;
-    video.height = 240;
+    video.width = targetWidth;
+    video.height = targetHeight;
     button.innerHTML = 'Capture!';
 
     button.onclick = function() {
         // create a canvas and capture a frame from video stream
         var canvas = document.createElement('canvas');
-        canvas.getContext('2d').drawImage(video, 0, 0, 320, 240);
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
+        canvas.getContext('2d').drawImage(video, 0, 0, targetWidth, targetHeight);
 
         // convert image stored in canvas to base64 encoded image
         var imageData = canvas.toDataURL('image/png');

--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -69,7 +69,7 @@ function capture(success, errorCallback) {
         canvas.getContext('2d').drawImage(video, 0, 0, 320, 240);
 
         // convert image stored in canvas to base64 encoded image
-        var imageData = canvas.toDataURL('img/png');
+        var imageData = canvas.toDataURL('image/png');
         imageData = imageData.replace('data:image/png;base64,', '');
 
         // stop video stream, remove video and button.

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -524,9 +524,11 @@ static NSString* toBase64(NSData* data) {
         NSString* mediaType = [info objectForKey:UIImagePickerControllerMediaType];
         if ([mediaType isEqualToString:(NSString*)kUTTypeImage]) {
             [weakSelf resultForImage:cameraPicker.pictureOptions info:info completion:^(CDVPluginResult* res) {
-                [weakSelf.commandDelegate sendPluginResult:res callbackId:cameraPicker.callbackId];
-                weakSelf.hasPendingOperation = NO;
-                weakSelf.pickerController = nil;
+                if (![self usesGeolocation] || picker.sourceType != UIImagePickerControllerSourceTypeCamera) {
+                    [weakSelf.commandDelegate sendPluginResult:res callbackId:cameraPicker.callbackId];
+                    weakSelf.hasPendingOperation = NO;
+                    weakSelf.pickerController = nil;
+                }
             }];
         }
         else {

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -240,9 +240,13 @@ static NSString* toBase64(NSData* data) {
 
 - (void)repositionPopover:(CDVInvokedUrlCommand*)command
 {
-    NSDictionary* options = [command argumentAtIndex:0 withDefault:nil];
+    if (([[self pickerController] pickerPopoverController] != nil) && [[[self pickerController] pickerPopoverController] isPopoverVisible]) {
 
-    [self displayPopover:options];
+        [[[self pickerController] pickerPopoverController] dismissPopoverAnimated:NO];
+
+        NSDictionary* options = [command argumentAtIndex:0 withDefault:nil];
+        [self displayPopover:options];
+    }
 }
 
 - (NSInteger)integerValueForKey:(NSDictionary*)dict key:(NSString*)key defaultValue:(NSInteger)defaultValue

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-camera-tests"
-    version="2.2.0">
+    version="2.2.1-dev">
     <name>Cordova Camera Plugin Tests</name>
     <license>Apache 2.0</license>
     

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -99,16 +99,13 @@ for (var key in Camera) {
  * `cameraOptions`:
  *
  * - A `String` containing the Base64-encoded photo image.
- *
  * - A `String` representing the image file location on local storage (default).
  *
  * You can do whatever you want with the encoded image or URI, for
  * example:
  *
  * - Render the image in an `<img>` tag, as in the example below
- *
  * - Save the data locally (`LocalStorage`, [Lawnchair](http://brianleroux.github.com/lawnchair/), etc.)
- *
  * - Post the data to a remote server
  *
  * __NOTE__: Photo resolution on newer devices is quite good. Photos

--- a/www/CameraConstants.js
+++ b/www/CameraConstants.js
@@ -24,6 +24,13 @@
  */
 module.exports = {
   /**
+   * @description
+   * Defines the output format of `Camera.getPicture` call.
+   * _Note:_ On iOS passing `DestinationType.NATIVE_URI` along with
+   * `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM` will
+   * disable any image modifications (resize, quality change, cropping, etc.) due
+   * to implementation specific.
+   *
    * @enum {number}
    */
   DestinationType:{
@@ -55,6 +62,12 @@ module.exports = {
     ALLMEDIA : 2
   },
   /**
+   * @description
+   * Defines the output format of `Camera.getPicture` call.
+   * _Note:_ On iOS passing `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM`
+   * along with `DestinationType.NATIVE_URI` will disable any image modifications (resize, quality
+   * change, cropping, etc.) due to implementation specific.
+   *
    * @enum {number}
    */
   PictureSourceType:{


### PR DESCRIPTION
Last plugin version. iOS works fine, when try to open camera/gallery on Android - nothing happens both in devices and emulator (no matter what version). 

```
 $scope.takePhoto = function () {
        var options = {
            quality: 75,
            destinationType: Camera.DestinationType.DATA_URL,
            sourceType: Camera.PictureSourceType.CAMERA,
            allowEdit: false,
            encodingType: Camera.EncodingType.JPEG,
            targetWidth: 217,
            targetHeight: 217,
            popoverOptions: CameraPopoverOptions,
            saveToPhotoAlbum: false
        };  
```

Tried to remove and add plugin and thats doesnt help... What shout I do?