### PR TITLE
CB-11447 Fix Appium camera tests failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,13 @@ one of the following formats, depending on the specified
 `cameraOptions`:
 
 - A `String` containing the Base64-encoded photo image.
-
 - A `String` representing the image file location on local storage (default).
 
 You can do whatever you want with the encoded image or URI, for
 example:
 
 - Render the image in an `<img>` tag, as in the example below
-
 - Save the data locally (`LocalStorage`, [Lawnchair](http://brianleroux.github.com/lawnchair/), etc.)
-
 - Post the data to a remote server
 
 __NOTE__: Photo resolution on newer devices is quite good. Photos
@@ -258,6 +255,12 @@ Optional parameters to customize the camera settings.
 <a name="module_Camera.DestinationType"></a>
 
 ### Camera.DestinationType : <code>enum</code>
+Defines the output format of `Camera.getPicture` call.
+_Note:_ On iOS passing `DestinationType.NATIVE_URI` along with
+`PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM` will
+disable any image modifications (resize, quality change, cropping, etc.) due
+to implementation specific.
+
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
 
@@ -293,6 +296,11 @@ Optional parameters to customize the camera settings.
 <a name="module_Camera.PictureSourceType"></a>
 
 ### Camera.PictureSourceType : <code>enum</code>
+Defines the output format of `Camera.getPicture` call.
+_Note:_ On iOS passing `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM`
+along with `DestinationType.NATIVE_URI` will disable any image modifications (resize, quality
+change, cropping, etc.) due to implementation specific.
+
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
 
@@ -530,6 +538,8 @@ Tizen only supports a `destinationType` of
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
 
 - When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
+
+- When using `destinationType.NATIVE_URI` and `sourceType.PHOTOLIBRARY` or `sourceType.SAVEDPHOTOALBUM`, all editing options are ignored and link is returned to original picture.
 
 #### Tizen Quirks
 

--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -119,10 +119,19 @@ module.exports.checkPicture = function (pid, options, cb) {
     var isAndroid = cordova.platformId === "android";
     // skip image type check if it's unmodified on Android:
     // https://github.com/apache/cordova-plugin-camera/#android-quirks-1
-    var skipFileTypeCheck = isAndroid &&
-        options.quality === 100 &&
+    var skipFileTypeCheckAndroid = isAndroid && options.quality === 100 &&
         !options.targetWidth && !options.targetHeight &&
         !options.correctOrientation;
+
+    // Skip image type check if destination is NATIVE_URI and source - device's photoalbum
+    // https://github.com/apache/cordova-plugin-camera/#ios-quirks-1
+    // TODO: correct link above
+    var skipFileTypeCheckiOS = isIos && options.destinationType === Camera.DestinationType.NATIVE_URI &&
+        (options.sourceType === Camera.PictureSourceType.PHOTOLIBRARY ||
+         options.sourceType === Camera.PictureSourceType.SAVEDPHOTOALBUM);
+
+    var skipFileTypeCheck = skipFileTypeCheckAndroid || skipFileTypeCheckiOS;
+
     var desiredType = 'JPEG';
     var mimeType = 'image/jpeg';
     if (options.encodingType === Camera.EncodingType.PNG) {

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -286,7 +286,7 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.6 Verifying target image size, sourceType=CAMERA, destinationType=NATIVE_URI', function (done) {
+        it('camera.ui.spec.6 Verifying target image size, sourceType=CAMERA, destinationType=FILE_URL', function (done) {
             // remove this line if you don't mind the tests leaving a photo saved on device
             pending('Cannot prevent iOS from saving the picture to photo library');
 
@@ -298,7 +298,7 @@ describe('Camera tests iOS.', function () {
                 quality: 50,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.CAMERA,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 210,
                 targetHeight: 210
@@ -307,13 +307,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.7 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=NATIVE_URI', function (done) {
+        it('camera.ui.spec.7 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=FILE_URL', function (done) {
             checkSession(done);
             var options = {
                 quality: 50,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 210,
                 targetHeight: 210
@@ -322,13 +322,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=NATIVE_URI', function (done) {
+        it('camera.ui.spec.8 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=FILE_URL', function (done) {
             checkSession(done);
             var options = {
                 quality: 50,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 210,
                 targetHeight: 210
@@ -337,7 +337,7 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.9 Verifying target image size, sourceType=CAMERA, destinationType=NATIVE_URI, quality=100', function (done) {
+        it('camera.ui.spec.9 Verifying target image size, sourceType=CAMERA, destinationType=FILE_URL, quality=100', function (done) {
             // remove this line if you don't mind the tests leaving a photo saved on device
             pending('Cannot prevent iOS from saving the picture to photo library');
 
@@ -349,7 +349,7 @@ describe('Camera tests iOS.', function () {
                 quality: 100,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.CAMERA,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 305,
                 targetHeight: 305
@@ -357,13 +357,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.10 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=NATIVE_URI, quality=100', function (done) {
+        it('camera.ui.spec.10 Verifying target image size, sourceType=SAVEDPHOTOALBUM, destinationType=FILE_URL, quality=100', function (done) {
             checkSession(done);
             var options = {
                 quality: 100,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 305,
                 targetHeight: 305
@@ -372,13 +372,13 @@ describe('Camera tests iOS.', function () {
             runSpec(options).done(done);
         }, 3 * MINUTE);
 
-        it('camera.ui.spec.11 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=NATIVE_URI, quality=100', function (done) {
+        it('camera.ui.spec.11 Verifying target image size, sourceType=PHOTOLIBRARY, destinationType=FILE_URL, quality=100', function (done) {
             checkSession(done);
             var options = {
                 quality: 100,
                 allowEdit: false,
                 sourceType: cameraConstants.PictureSourceType.PHOTOLIBRARY,
-                destinationType: cameraConstants.DestinationType.NATIVE_URI,
+                destinationType: cameraConstants.DestinationType.FILE_URL,
                 saveToPhotoAlbum: false,
                 targetWidth: 305,
                 targetHeight: 305

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -187,6 +187,8 @@ Tizen only supports a `destinationType` of
 
 - When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
 
+- When using `destinationType.NATIVE_URI` and `sourceType.PHOTOLIBRARY` or `sourceType.SAVEDPHOTOALBUM`, all editing options are ignored and link is returned to original picture.
+
 #### Tizen Quirks
 
 - options not supported

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -365,7 +365,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     intent.putExtra("aspectX", 1);
                     intent.putExtra("aspectY", 1);
                 }
-                File photo = createCaptureFile(encodingType);
+                File photo = createCaptureFile(JPEG);
                 croppedUri = Uri.fromFile(photo);
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, croppedUri);
             } else {
@@ -592,15 +592,29 @@ private void refreshGallery(Uri contentUri)
     this.cordova.getActivity().sendBroadcast(mediaScanIntent);
 }
 
+    /**
+     * Converts output image format int value to string value of mime type.
+     * @param outputFormat int Output format of camera API.
+     *                     Must be value of either JPEG or PNG constant
+     * @return String String value of mime type or empty string if mime type is not supported
+     */
+    private String getMimetypeForFormat(int outputFormat) {
+        if (outputFormat == PNG) return "image/png";
+        if (outputFormat == JPEG) return "image/jpeg";
+        return "";
+    }
 
-private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
+    private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
         // Some content: URIs do not map to file paths (e.g. picasa).
         String realPath = FileHelper.getRealPath(uri, this.cordova);
 
         // Get filename from uri
         String fileName = realPath != null ?
-            realPath.substring(realPath.lastIndexOf('/') + 1) :
-            "modified." + (this.encodingType == JPEG ? "jpg" : "png");
+            realPath.substring(realPath.lastIndexOf('/') + 1, realPath.lastIndexOf(".") + 1) :
+            "modified.";
+
+        // Append filename extension based on output encoding type
+        fileName += (this.encodingType == JPEG ? "jpg" : "png");
 
         String modifiedPath = getTempDirectoryPath() + "/" + fileName;
 
@@ -660,15 +674,18 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
             this.callbackContext.success(fileLocation);
         }
         else {
+            String uriString = uri.toString();
+            // Get the path to the image. Makes loading so much easier.
+            String mimeType = FileHelper.getMimeType(uriString, this.cordova);
+
             // This is a special case to just return the path as no scaling,
             // rotating, nor compressing needs to be done
             if (this.targetHeight == -1 && this.targetWidth == -1 &&
-                    (destType == FILE_URI || destType == NATIVE_URI) && !this.correctOrientation) {
-                this.callbackContext.success(uri.toString());
+                    (destType == FILE_URI || destType == NATIVE_URI) && !this.correctOrientation &&
+                    mimeType.equalsIgnoreCase(getMimetypeForFormat(encodingType)))
+            {
+                this.callbackContext.success(uriString);
             } else {
-                String uriString = uri.toString();
-                // Get the path to the image. Makes loading so much easier.
-                String mimeType = FileHelper.getMimeType(uriString, this.cordova);
                 // If we don't have a valid image so quit.
                 if (!("image/jpeg".equalsIgnoreCase(mimeType) || "image/png".equalsIgnoreCase(mimeType))) {
                     Log.d(LOG_TAG, "I either have a null image path or bitmap");
@@ -710,7 +727,9 @@ private String ouputModifiedBitmap(Bitmap bitmap, Uri uri) throws IOException {
                 else if (destType == FILE_URI || destType == NATIVE_URI) {
                     // Did we modify the image?
                     if ( (this.targetHeight > 0 && this.targetWidth > 0) ||
-                            (this.correctOrientation && this.orientationCorrected) ) {
+                            (this.correctOrientation && this.orientationCorrected) ||
+                            !mimeType.equalsIgnoreCase(getMimetypeForFormat(encodingType)))
+                    {
                         try {
                             String modifiedPath = this.ouputModifiedBitmap(bitmap, uri);
                             // The modified image is cached by the app in order to get around this and not have to delete you

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -99,16 +99,13 @@ for (var key in Camera) {
  * `cameraOptions`:
  *
  * - A `String` containing the Base64-encoded photo image.
- *
  * - A `String` representing the image file location on local storage (default).
  *
  * You can do whatever you want with the encoded image or URI, for
  * example:
  *
  * - Render the image in an `<img>` tag, as in the example below
- *
  * - Save the data locally (`LocalStorage`, [Lawnchair](http://brianleroux.github.com/lawnchair/), etc.)
- *
  * - Post the data to a remote server
  *
  * __NOTE__: Photo resolution on newer devices is quite good. Photos

--- a/www/CameraConstants.js
+++ b/www/CameraConstants.js
@@ -24,6 +24,13 @@
  */
 module.exports = {
   /**
+   * @description
+   * Defines the output format of `Camera.getPicture` call.
+   * _Note:_ On iOS passing `DestinationType.NATIVE_URI` along with
+   * `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM` will
+   * disable any image modifications (resize, quality change, cropping, etc.) due
+   * to implementation specific.
+   *
    * @enum {number}
    */
   DestinationType:{
@@ -55,6 +62,12 @@ module.exports = {
     ALLMEDIA : 2
   },
   /**
+   * @description
+   * Defines the output format of `Camera.getPicture` call.
+   * _Note:_ On iOS passing `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM`
+   * along with `DestinationType.NATIVE_URI` will disable any image modifications (resize, quality
+   * change, cropping, etc.) due to implementation specific.
+   *
    * @enum {number}
    */
   PictureSourceType:{


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android, iOS

### What does this PR do?
This PR resolves issues w/ the plugin (and tests), discovered by Appium tests:

1. on iOS plugin does not modify resultant file (no compression, format change or resizing is performed) when source is PHOTOGALLERY and output is NATIVE_URI. This is not well-documented in README and hadn't been taken into account when tests were being written.
2. On Android when output type is `PNG` and image has been picked from gallery, this results in skipping `jpeg` -> `png` conversion. The output file is saved in `jpeg` format even if file extension might be `.png`.

An example of failed tests can be found here: 
- For Android: [PLATFORM=android,PLUGIN=cordova-plugin-camera](http://cordova-ci.cloudapp.net:8080/view/Periodic%20builds/job/cordova-periodic-build/PLATFORM=android,PLUGIN=cordova-plugin-camera)
- For iOS: [PLATFORM=ios,PLUGIN=cordova-plugin-camera](http://cordova-ci.cloudapp.net:8080/view/Periodic%20builds/job/cordova-periodic-build/PLATFORM=ios,PLUGIN=cordova-plugin-camera)

### What testing has been done on this change?
Manual tests and automated testing via `cordova-paramedic`

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
