### PR TITLE
add CAMERA and READ_EXTERNAL_STORAGE permissions to the manifest file…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -68,6 +68,9 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.CAMERA" />
+
         </config-file>
 
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected

Android
### What does this PR do?

Adds permissions declarations to manifest file so they can be adjusted in the settings dialogs in Android app settings.

Otherwise, a user may decline or disallow the permissions and request time and they are unable to reenable them.
### What testing has been done on this change?

Test on a pre-production app.
### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

… so they can be enabled/disabled in the application manager settings for the application (plus they are requested at runtime now too).

fixes CB-11689
