### PR TITLE
CB-11709 Tests should use resolveLocalFileSystemURL()

### DIFF
--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -1,5 +1,5 @@
 /*jshint node: true */
-/* global Q, resolveLocalFileSystemURI, Camera, cordova */
+/* global Q, resolveLocalFileSystemURL, Camera, cordova */
 /*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -174,11 +174,11 @@ module.exports.checkPicture = function (pid, options, cb) {
                 result.indexOf('content:') === 0 ||
                 result.indexOf('assets-library:') === 0) {
 
-                if (!window.resolveLocalFileSystemURI) {
+                if (!window.resolveLocalFileSystemURL) {
                     errorCallback('Cannot read file. Please install cordova-plugin-file to fix this.');
                     return;
                 }
-                resolveLocalFileSystemURI(result, function (entry) {
+                resolveLocalFileSystemURL(result, function (entry) {
                     if (skipFileTypeCheck) {
                         displayFile(entry);
                     } else {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -19,7 +19,7 @@
  *
 */
 
-/* globals Camera, resolveLocalFileSystemURI, FileEntry, CameraPopoverOptions, FileTransfer, FileUploadOptions, LocalFileSystem, MSApp */
+/* globals Camera, resolveLocalFileSystemURL, FileEntry, CameraPopoverOptions, FileTransfer, FileUploadOptions, LocalFileSystem, MSApp */
 /* jshint jasmine: true */
 
 exports.defineAutoTests = function () {
@@ -142,11 +142,11 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         setPicture(data);
         // TODO: Fix resolveLocalFileSystemURI to work with native-uri.
         if (pictureUrl.indexOf('file:') === 0 || pictureUrl.indexOf('content:') === 0 || pictureUrl.indexOf('ms-appdata:') === 0 || pictureUrl.indexOf('assets-library:') === 0) {
-            resolveLocalFileSystemURI(data, function (e) {
+            resolveLocalFileSystemURL(data, function (e) {
                 fileEntry = e;
-                logCallback('resolveLocalFileSystemURI()', true)(e.toURL());
+                logCallback('resolveLocalFileSystemURL()', true)(e.toURL());
                 readFile();
-            }, logCallback('resolveLocalFileSystemURI()', false));
+            }, logCallback('resolveLocalFileSystemURL()', false));
         } else if (pictureUrl.indexOf('data:image/jpeg;base64') === 0) {
             // do nothing
         } else {
@@ -251,7 +251,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
 
             //cleanup
             //rename moved file back to original name so other tests can reference image
-            resolveLocalFileSystemURI(destDirEntry.nativeURL+'moved_file.png', function(fileEntry) {
+            resolveLocalFileSystemURL(destDirEntry.nativeURL+'moved_file.png', function(fileEntry) {
                 fileEntry.moveTo(destDirEntry, origName, logCallback('FileEntry.moveTo', true), logCallback('FileEntry.moveTo', false));
                 console.log('Cleanup: successfully renamed file back to original name');
             }, function () {
@@ -259,7 +259,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
             });
 
             //remove copied file
-            resolveLocalFileSystemURI(destDirEntry.nativeURL+'copied_file.png', function(fileEntry) {
+            resolveLocalFileSystemURL(destDirEntry.nativeURL+'copied_file.png', function(fileEntry) {
                 fileEntry.remove(logCallback('FileEntry.remove', true), logCallback('FileEntry.remove', false));
                 console.log('Cleanup: successfully removed copied file');
             }, function () {


### PR DESCRIPTION
### Platforms affected
Any

### What does this PR do?
Allows tests to use File plugin's resolveLocalFileSystemURL() method istead of deprecated resolveLocalFileSystemURI() method.

### What testing has been done on this change?
Tested Appium and Test Framework tests on Android 4.4 and iOS 8.4 emulators.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-11709) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.