### PR TITLE
CB-11714: (windows) added more explicit content-type when converting …

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -79,10 +79,14 @@ var HIGHEST_POSSIBLE_Z_INDEX = 2147483647;
 // Resize method
 function resizeImage(successCallback, errorCallback, file, targetWidth, targetHeight, encodingType) {
     var tempPhotoFileName = "";
+    var targetContentType = "";
+
     if (encodingType == Camera.EncodingType.PNG) {
         tempPhotoFileName = "camera_cordova_temp_return.png";
+        targetContentType = "image/png";
     } else {
         tempPhotoFileName = "camera_cordova_temp_return.jpg";
+        targetContentType = "image/jpeg";
     }
 
     var storageFolder = getAppData().localFolder;
@@ -108,7 +112,7 @@ function resizeImage(successCallback, errorCallback, file, targetWidth, targetHe
 
                 canvas.getContext("2d").drawImage(this, 0, 0, imageWidth, imageHeight);
 
-                var fileContent = canvas.toDataURL(file.contentType).split(',')[1];
+                var fileContent = canvas.toDataURL(targetContentType).split(',')[1];
 
                 var storageFolder = getAppData().localFolder;
 
@@ -745,7 +749,7 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     cameraCaptureUI.photoSettings.maxResolution = maxRes;
 
     var cameraPicture;
-    
+
     // define focus handler for windows phone 10.0
     var savePhotoOnFocus = function () {
         window.removeEventListener("focus", savePhotoOnFocus);
@@ -760,7 +764,7 @@ function takePictureFromCameraWindows(successCallback, errorCallback, args) {
     };
 
     // if windows phone 10, add and delete focus eventHandler to capture the focus back from cameraUI to app
-    if (navigator.appVersion.indexOf('Windows Phone 10.0') >= 0) { 
+    if (navigator.appVersion.indexOf('Windows Phone 10.0') >= 0) {
         window.addEventListener("focus", savePhotoOnFocus);
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Adds an explicit check for PNG/JPEG to set the content type when converting to target data URL in resizeImage()

### What testing has been done on this change?
Manual testing has been done using a Windows 10 Desktop.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

…nvas