### PR TITLE
targetWidth and targetHeight bigger than original picture

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1076,8 +1076,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @return
      */
     public int[] calculateAspectRatio(int origWidth, int origHeight) {
-        int newWidth = this.targetWidth;
-        int newHeight = this.targetHeight;
+        int newWidth = Math.min(this.targetWidth, origWidth);
+        int newHeight = Math.min(this.targetHeight, origHeight);
 
         // If no new width or height were specified return the original bitmap
         if (newWidth <= 0 && newHeight <= 0) {

--- a/src/ios/UIImage+CropScaleOrientation.m
+++ b/src/ios/UIImage+CropScaleOrientation.m
@@ -28,8 +28,8 @@
     CGSize imageSize = sourceImage.size;
     CGFloat width = imageSize.width;
     CGFloat height = imageSize.height;
-    CGFloat targetWidth = targetSize.width;
-    CGFloat targetHeight = targetSize.height;
+    CGFloat targetWidth = MIN(targetSize.width, width);
+    CGFloat targetHeight = MIN(targetSize.height, height);
     CGFloat scaleFactor = 0.0;
     CGFloat scaledWidth = targetWidth;
     CGFloat scaledHeight = targetHeight;
@@ -136,8 +136,8 @@
     CGSize imageSize = sourceImage.size;
     CGFloat width = imageSize.width;
     CGFloat height = imageSize.height;
-    CGFloat targetWidth = targetSize.width;
-    CGFloat targetHeight = targetSize.height;
+    CGFloat targetWidth = MIN(targetSize.width, width);
+    CGFloat targetHeight = MIN(targetSize.height, height);
     CGFloat scaleFactor = 0.0;
     CGSize scaledSize = targetSize;
     


### PR DESCRIPTION
### Platforms affected
Android, iOS (i can not test for other platforms)

### What does this PR do?
When setting targetWidth and targetHeight to a bigger size than original picture, the result picture should be sized like the original picture

### What testing has been done on this change?
I tested on version 2.3.0 on iPhone and android emulators.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x]  CB-11987: (android, ios) Fix bug with targetWidth and targetHeight bigger than original picture
- [ ] Added automated test coverage as appropriate for this change.