### PR TITLE
CB-12005: (android) Fix picture orientation from camera

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -554,6 +554,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 if (this.encodingType == JPEG) {
                     String exifPath;
                     exifPath = uri.getPath();
+                    //opbokel - Roteted files already have the correct orientation.
+                    if (this.correctOrientation && this.orientationCorrected) {
+                        exif.resetOrientation();
+                    }
                     exif.createOutFile(exifPath);
                     exif.writeExifData();
                 }

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -554,7 +554,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 if (this.encodingType == JPEG) {
                     String exifPath;
                     exifPath = uri.getPath();
-                    //opbokel - Roteted files already have the correct orientation.
+                    //opbokel - Rotated files already have the correct orientation.
                     if (this.correctOrientation && this.orientationCorrected) {
                         exif.resetOrientation();
                     }


### PR DESCRIPTION
### Platforms affected

Android (tested on 6.0.1)
### What does this PR do?

Resets the Exif orientation of the picture taken by the camera if it was successfully rotated 
### What testing has been done on this change?

It was a very small change, I tested in two devices, also tested using the gallery.
