### PR TITLE
CB-12086: Added NSPhotoLibraryUsageDescription parameter to example install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ When the system prompts the user to allow access, this string is displayed as pa
 To add this entry you can pass the following variables on plugin install.
 
 - `CAMERA_USAGE_DESCRIPTION` for `NSCameraUsageDescription`
-- `PHOTOLIBRARY_USAGE_DESCRIPTION` for `NSPhotoLibraryUsageDescription`
-
+- `PHOTOLIBRARY_USAGE_DESCRIPTION` for `NSPhotoLibraryUsageDescriptionentry`
+-
 Example:
 
-    cordova plugin add cordova-plugin-camera --variable CAMERA_USAGE_DESCRIPTION="your usage message" --variable PHOTOLIBRARY_USAGE_DESCRIPTION="your usage message"
+    cordova plugin add cordova-plugin-camera --variable CAMERA_USAGE_DESCRIPTION="your usage message"
 
 If you don't pass the variable, the plugin will add an empty string as value.
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ When the system prompts the user to allow access, this string is displayed as pa
 To add this entry you can pass the following variables on plugin install.
 
 - `CAMERA_USAGE_DESCRIPTION` for `NSCameraUsageDescription`
-- `PHOTOLIBRARY_USAGE_DESCRIPTION` for `NSPhotoLibraryUsageDescriptionentry`
--
+- `PHOTOLIBRARY_USAGE_DESCRIPTION` for `NSPhotoLibraryUsageDescription`
+
 Example:
 
-    cordova plugin add cordova-plugin-camera --variable CAMERA_USAGE_DESCRIPTION="your usage message"
+    cordova plugin add cordova-plugin-camera --variable CAMERA_USAGE_DESCRIPTION="your usage message" --variable PHOTOLIBRARY_USAGE_DESCRIPTION="your usage message"
 
 If you don't pass the variable, the plugin will add an empty string as value.
 

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -18,21 +18,21 @@ the system's image library.
 
 ### iOS Quirks
 
-Since iOS 10 it's mandatory to add a `NSCameraUsageDescription` and `NSPhotoLibraryUsageDescriptionentry` in the info.plist.
+Since iOS 10 it's mandatory to add a `NSCameraUsageDescription` and `NSPhotoLibraryUsageDescription` in the info.plist.
 
 - `NSCameraUsageDescription` describes the reason that the app accesses the user’s camera.
-- `NSPhotoLibraryUsageDescriptionentry` describes the reason the app accesses the user's photo library. 
+- `NSPhotoLibraryUsageDescription` describes the reason the app accesses the user's photo library. 
 
 When the system prompts the user to allow access, this string is displayed as part of the dialog box. 
 
 To add this entry you can pass the following variables on plugin install.
 
 - `CAMERA_USAGE_DESCRIPTION` for `NSCameraUsageDescription`
-- `PHOTOLIBRARY_USAGE_DESCRIPTION` for `NSPhotoLibraryUsageDescriptionentry`
--
+- `PHOTOLIBRARY_USAGE_DESCRIPTION` for `NSPhotoLibraryUsageDescription`
+
 Example:
 
-    cordova plugin add cordova-plugin-camera --variable CAMERA_USAGE_DESCRIPTION="your usage message"
+    cordova plugin add cordova-plugin-camera --variable CAMERA_USAGE_DESCRIPTION="your usage message" --variable PHOTOLIBRARY_USAGE_DESCRIPTION="your usage message"
 
 If you don't pass the variable, the plugin will add an empty string as value.
 


### PR DESCRIPTION
Very minor doc update to fix formatting and add the other (necessary for Apple Store) usage description.
