### PR TITLE
CB-11714: (windows) added check for encoding in savePhoto() without height/width

### DIFF
--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -801,13 +801,11 @@ function savePhoto(picture, options, successCallback, errorCallback) {
                 resizeImage(successCallback, errorCallback, picture, options.targetWidth, options.targetHeight, options.encodingType);
             } else {
                 // CB-11714: check if target content-type is PNG to just rename as *.jpg since camera is captured as JPEG
-                var pictureName = picture.name;
-
                 if (options.encodingType === Camera.EncodingType.PNG) {
-                    pictureName = pictureName.replace(/\.png$/, ".jpg");
+                    picture.name = picture.name.replace(/\.png$/, ".jpg");
                 }
 
-                picture.copyAsync(getAppData().localFolder, pictureName, OptUnique).done(function (copiedFile) {
+                picture.copyAsync(getAppData().localFolder, picture.name, OptUnique).done(function (copiedFile) {
                     successCallback('ms-appdata:///local/' + copiedFile.name);
                 }, errorCallback);
             }

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -802,7 +802,7 @@ function savePhoto(picture, options, successCallback, errorCallback) {
             } else {
                 // CB-11714: check if target content-type is PNG to just rename as *.jpg since camera is captured as JPEG
                 if (options.encodingType === Camera.EncodingType.PNG) {
-                    picture.name = picture.name.replace(/\.png$/, ".jpg");
+                    picture.name = picture.name.replace(/\.png$/, '.jpg');
                 }
 
                 picture.copyAsync(getAppData().localFolder, picture.name, OptUnique).done(function (copiedFile) {

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -800,9 +800,16 @@ function savePhoto(picture, options, successCallback, errorCallback) {
             if (options.targetHeight > 0 && options.targetWidth > 0) {
                 resizeImage(successCallback, errorCallback, picture, options.targetWidth, options.targetHeight, options.encodingType);
             } else {
-                picture.copyAsync(getAppData().localFolder, picture.name, OptUnique).done(function (copiedFile) {
-                    successCallback("ms-appdata:///local/" + copiedFile.name);
-                },errorCallback);
+                // CB-11714: check if target content-type is PNG to just rename as *.jpg since camera is captured as JPEG
+                var pictureName = picture.name;
+
+                if (options.encodingType === Camera.EncodingType.PNG) {
+                    pictureName = pictureName.replace(/\.png$/, ".jpg");
+                }
+
+                picture
+                    .copyAsync(getAppData().localFolder, pictureName, OptUnique)
+                    .done(function (copiedFile) { successCallback("ms-appdata:///local/" + copiedFile.name); }, errorCallback);
             }
         } else {
             if (options.targetHeight > 0 && options.targetWidth > 0) {

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -807,9 +807,9 @@ function savePhoto(picture, options, successCallback, errorCallback) {
                     pictureName = pictureName.replace(/\.png$/, ".jpg");
                 }
 
-                picture
-                    .copyAsync(getAppData().localFolder, pictureName, OptUnique)
-                    .done(function (copiedFile) { successCallback("ms-appdata:///local/" + copiedFile.name); }, errorCallback);
+                picture.copyAsync(getAppData().localFolder, pictureName, OptUnique).done(function (copiedFile) {
+                    successCallback('ms-appdata:///local/' + copiedFile.name);
+                }, errorCallback);
             }
         } else {
             if (options.targetHeight > 0 && options.targetWidth > 0) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows 10

### What does this PR do?
Adds extra content-type check when capturing photos without specifying targetWidth and/or targetHeight in options to preserve JPEG file extension.

### What testing has been done on this change?
ditto

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.