### PR TITLE
Double exif rotation on android with camera

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -556,13 +556,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 os.close();
 
                 // Restore exif data to file
+                   /*
                 if (this.encodingType == JPEG) {
                     String exifPath;
                     exifPath = uri.getPath();
                     exif.createOutFile(exifPath);
                     exif.writeExifData();
                 }
-
+                     */
                 // Send Uri back to JavaScript for viewing image
                 this.callbackContext.success(uri.toString());
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
This solves the "correctOrientation not rotating / wrong orientation with Android camera bug"

### What testing has been done on this change?
Single Android device

If flag correctOrientation is set the image is rotated according to EXIF-data. After this, the original EXIF-data is added back to the image where the rotation is stil there. Result is that instead of a wrongly rotated image with EXIF-data to correct you end up with a correctly rotated image with EXIF-data that tilts the image 90 degrees.

Removing the EXIF completely solves this for me - there should be a more elegant solution to just remove the "orientation" data from the EXIF to make this a more general purpose solution.