### PR TITLE
Handle OutOfMemoryError exception when scaling a picture

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1066,7 +1066,13 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             int scaledWidth = (!rotated) ? widthHeight[0] : widthHeight[1];
             int scaledHeight = (!rotated) ? widthHeight[1] : widthHeight[0];
 
-            Bitmap scaledBitmap = Bitmap.createScaledBitmap(unscaledBitmap, scaledWidth, scaledHeight, true);
+            Bitmap scaledBitmap;
+            try {
+                scaledBitmap = Bitmap.createScaledBitmap(unscaledBitmap, scaledWidth, scaledHeight, true);
+            }
+            catch (Error e) { // Throws OutOfMemoryError on some low-end devices
+                scaledBitmap = unscaledBitmap;
+            }
             if (scaledBitmap != unscaledBitmap) {
                 unscaledBitmap.recycle();
                 unscaledBitmap = null;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Handles OutOfMemoryError exception when scaling/rotating a picture.
The problem has been reproduced on Samsung S3 when taking a picture in portrait mode when setCorrectOrientation is true. The app was crashing on that place.

### What testing has been done on this change?
Tested after this fix and the app is not crashing anymore, although the picture stays rotated to landscape, as expected

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
