### PR TITLE
Fix number for sdk comparison.

### DIFF
--- a/src/android/CordovaUri.java
+++ b/src/android/CordovaUri.java
@@ -75,7 +75,7 @@ public class CordovaUri {
 
     public Uri getCorrectUri()
     {
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+        if(Build.VERSION.SDK_INT >= 23)
             return androidUri;
         else
             return fileUri;


### PR DESCRIPTION
Older sdk versions can't be built, because they don't know the constant.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Fixes a bug while build. With this PR you can build with older SDKs.

Someone with the same Problem:
http://stackoverflow.com/questions/41492956/something-wrong-with-compiling-ionic-project

### What testing has been done on this change?
Install and build with older Android-sdk.

### Checklist
- [ -] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [- ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [- ] Added automated test coverage as appropriate for this change.
