### PR TITLE
CB-12458 - [cordova-plugin-camera] - The information about old versio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Although the object is attached to the global scoped `navigator`, it is not avai
 This requires cordova 5.0+
 
     cordova plugin add cordova-plugin-camera
-Older versions of cordova can still install via the __deprecated__ id
+Older versions of cordova or this plugin can still install via the __deprecated__ id
 
     cordova plugin add org.apache.cordova.camera
 It is also possible to install via repo url directly ( unstable )

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Although the object is attached to the global scoped `navigator`, it is not avai
 This requires cordova 5.0+
 
     cordova plugin add cordova-plugin-camera
-Older versions of cordova or this plugin can still install via the __deprecated__ id
+A older versions of cordova cli(version < 5.0) can still install via the __deprecated__ id
 
     cordova plugin add org.apache.cordova.camera
 It is also possible to install via repo url directly ( unstable )

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ It is also possible to install via repo url directly ( unstable )
 
     cordova plugin add https://github.com/apache/cordova-plugin-camera.git
 
+** Note:** 
+The id is picked from the `package.json` or `plugin.xml` and on versions < 1 the id is the __deprecated__ id. 
+The following are some examples.
+- plugin < 1 : https://github.com/apache/cordova-plugin-camera/blob/r0.3.6/package.json#L6
+- plugin >= 1 : https://github.com/apache/cordova-plugin-camera/blob/r1.0.0/package.json#L6
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Although the object is attached to the global scoped `navigator`, it is not avai
 This requires cordova 5.0+
 
     cordova plugin add cordova-plugin-camera
-A older versions of cordova cli(version < 5.0) can still install via the __deprecated__ id
+An older versions of cordova cli(version < 5.0) can still install via the __deprecated__ id
 
     cordova plugin add org.apache.cordova.camera
 It is also possible to install via repo url directly ( unstable )

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is also possible to install via repo url directly ( unstable )
 
     cordova plugin add https://github.com/apache/cordova-plugin-camera.git
 
-** Note:** 
+**Note:** 
 The id is picked from the `package.json` or `plugin.xml` and on versions < 1 the id is the __deprecated__ id. 
 The following are some examples.
 - plugin < 1 : https://github.com/apache/cordova-plugin-camera/blob/r0.3.6/package.json#L6


### PR DESCRIPTION
…ns of the plugin install the deprecated ID

CB-12458 - [cordova-plugin-camera] - The information about old versions of the plugin install the deprecated ID

Changed in the text to make it clear. Referent the JIRA: https://issues.apache.org/jira/browse/CB-12458

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
