### PR TITLE
CB-12618: (android) Appium tests: Handle native cling

### DIFF
--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -610,6 +610,15 @@ describe('Camera tests Android.', function () {
                 .deviceKeyEvent(BACK_BUTTON)
                 .elementById('Apps')
                 .click()
+                .then(function () {
+                    return driver
+                        .elementByXPath('//android.widget.Button[@text="OK"]')
+                        .click()
+                        .fail(function () {
+                            // no cling is all right
+                            // it is not a brand new emulator, then
+                        });
+                })
                 .elementByAndroidUIAutomator('new UiSelector().text("Gallery")')
                 .click()
                 .elementByAndroidUIAutomator('new UiSelector().textContains("Pictures")')


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Enables Appium tests to handle native cling on Android which prevents them from removing temporary image from the image gallery.
https://issues.apache.org/jira/browse/CB-12618

### What testing has been done on this change?
Android 4.4: local and Sauce Labs run

### Checklist
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-12618) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
