### PR TITLE
CB-12622: (android) Appium tests: Bust Android 6 and 7 permission dia…

### DIFF
--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -225,6 +225,40 @@ describe('Camera tests Android.', function () {
             })
             .waitForDeviceReady()
             .injectLibraries()
+            .then(function () {
+                var options = {
+                    quality: 50,
+                    allowEdit: false,
+                    sourceType: cameraConstants.PictureSourceType.SAVEDPHOTOALBUM,
+                    saveToPhotoAlbum: false,
+                    targetWidth: 210,
+                    targetHeight: 210
+                };
+                return driver
+                    .then(function () { return getPicture(options, true); })
+                    .context(CONTEXT_NATIVE_APP)
+                    // case insensitive select, will be handy with Android 7 support
+                    .elementByXPath('//android.widget.Button[translate(@text, "alow", "ALOW")="ALLOW"]')
+                    .click()
+                    .fail(function noAlert() { })
+                    .deviceKeyEvent(BACK_BUTTON)
+                    .sleep(2000)
+                    .elementById('action_bar_title')
+                    .then(function () {
+                        // success means we're still in native app
+                        return driver
+                            .deviceKeyEvent(BACK_BUTTON);
+                        }, function () {
+                            // error means we're already in webview
+                            return driver;
+                        });
+            })
+            .then(function () {
+                // doing it inside a function because otherwise 
+                // it would not hook up to the webviewContext var change
+                // in the first methods of this chain
+                return driver.context(webviewContext);
+            })
             .deleteFillerImage(fillerImagePath)
             .then(function () {
                 fillerImagePath = null;
@@ -291,6 +325,7 @@ describe('Camera tests Android.', function () {
             pending('This test requires a functioning camera on the Android device/emulator, and this test suite\'s functional camera test failed on your target environment.');
         }
     }
+
     afterAll(function (done) {
         checkSession(done);
         driver
@@ -390,7 +425,7 @@ describe('Camera tests Android.', function () {
                         return driver
                             .elementByAndroidUIAutomator('new UiSelector().text("Choose video")')
                             .fail(function () {
-                                throw 'Couldn\'t find "Choose video" element.';
+                                throw 'Couldn\'t find a "Choose video" element.';
                             });
                     })
                     .deviceKeyEvent(BACK_BUTTON)

--- a/appium-tests/helpers/cameraHelper.js
+++ b/appium-tests/helpers/cameraHelper.js
@@ -169,6 +169,7 @@ module.exports.checkPicture = function (pid, options, cb) {
                 return;
             }
         }
+
         try {
             if (result.indexOf('file:') === 0 ||
                 result.indexOf('content:') === 0 ||
@@ -184,6 +185,8 @@ module.exports.checkPicture = function (pid, options, cb) {
                     } else {
                         verifyFile(entry);
                     }
+                }, function (err) {
+                    errorCallback(err);
                 });
             } else {
                 displayImage(result);


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Enables Appium tests to run on Android 6 emulators and brings Android 7 runs a bit closer.

### What testing has been done on this change?
A couple of SauceLabs runs

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
