### PR TITLE
change CameraOptions of README.md in ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Optional parameters to customize the camera settings.
 | quality | <code>number</code> | <code>50</code> | Quality of the saved image, expressed as a range of 0-100, where 100 is typically full resolution with no loss from file compression. (Note that information about the camera's resolution is unavailable.) |
 | destinationType | <code>[DestinationType](#module_Camera.DestinationType)</code> | <code>FILE_URI</code> | Choose the format of the return value. |
 | sourceType | <code>[PictureSourceType](#module_Camera.PictureSourceType)</code> | <code>CAMERA</code> | Set the source of the picture. |
-| allowEdit | <code>Boolean</code> | <code>true</code> | Allow simple editing of image before selection. |
+| allowEdit | <code>Boolean</code> | <code>false</code> | Allow simple editing of image before selection. |
 | encodingType | <code>[EncodingType](#module_Camera.EncodingType)</code> | <code>JPEG</code> | Choose the  returned image file's encoding. |
 | targetWidth | <code>number</code> |  | Width in pixels to scale image. Must be used with `targetHeight`. Aspect ratio remains constant. |
 | targetHeight | <code>number</code> |  | Height in pixels to scale image. Must be used with `targetWidth`. Aspect ratio remains constant. |

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -66,7 +66,7 @@ for (var key in Camera) {
  * @property {number} [quality=50] - Quality of the saved image, expressed as a range of 0-100, where 100 is typically full resolution with no loss from file compression. (Note that information about the camera's resolution is unavailable.)
  * @property {module:Camera.DestinationType} [destinationType=FILE_URI] - Choose the format of the return value.
  * @property {module:Camera.PictureSourceType} [sourceType=CAMERA] - Set the source of the picture.
- * @property {Boolean} [allowEdit=true] - Allow simple editing of image before selection.
+ * @property {Boolean} [allowEdit=false] - Allow simple editing of image before selection.
  * @property {module:Camera.EncodingType} [encodingType=JPEG] - Choose the  returned image file's encoding.
  * @property {number} [targetWidth] - Width in pixels to scale image. Must be used with `targetHeight`. Aspect ratio remains constant.
  * @property {number} [targetHeight] - Height in pixels to scale image. Must be used with `targetWidth`. Aspect ratio remains constant.


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
it modified on README.md.
it may be wrong.

In README.md
 - `allowEdit` is `true` on default in CameraOptions.

but, actually `allowEdit` default value is `false`.
In a part of `www/Camera.js`
```
cameraExport.getPicture = function(successCallback, errorCallback, options) {
    options = options || {};

    var allowEdit = !!options.allowEdit;    // if do not set value, this allowEdit is false
};
```

### What testing has been done on this change?

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
