### PR TITLE
CB-12964: (android) Fix of bug when Pictures folder did not exist.

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -601,6 +601,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         String imageFileName = "IMG_" + timeStamp + (this.encodingType == JPEG ? ".jpg" : ".png");
         File storageDir = Environment.getExternalStoragePublicDirectory(
                 Environment.DIRECTORY_PICTURES);
+        storageDir.mkdirs();
         String galleryPath = storageDir.getAbsolutePath() + "/" + imageFileName;
         return galleryPath;
     }


### PR DESCRIPTION
If someone had removed Pictures folder in android, plugin failed trying to move there the new photo. This happened because plugin did not check the existence of this folder, and if not, it did not complete the folder tree.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
It makes plugin to create Pictures folder, if it has enough permissions (if not, an exception will be thrown and caught in the usual way), because until this time, in case of user had deleted this folder, the plugin failed.

### What testing has been done on this change?
I have tested that in an Android application using this plugin, when Pictures folder was deleted, the plugin works normally after change and not before.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
