### PR TITLE
CB-12982: (Android, iOS) Appium tests: try to create a session harder

### DIFF
--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -369,12 +369,20 @@ describe('Camera tests Android.', function () {
     }, MINUTE);
 
     it('camera.ui.util configuring driver and starting a session', function (done) {
+        // retry up to 3 times
         getDriver()
+            .fail(function () {
+                return getDriver()
+                    .fail(function () {
+                        return getDriver()
+                            .fail(fail);
+                    });
+            })
             .then(function () {
                 appiumSessionStarted = true;
-            }, fail)
+            })
             .done(done);
-    }, 10 * MINUTE);
+    }, 30 * MINUTE);
 
     it('camera.ui.util determine screen dimensions', function (done) {
         checkSession(done, /*skipResolutionCheck?*/ true); // skip the resolution check here since we are about to find out in this spec!
@@ -732,3 +740,4 @@ describe('Camera tests Android.', function () {
     });
 
 });
+

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -273,10 +273,18 @@ describe('Camera tests iOS.', function () {
     }
 
     it('camera.ui.util configure driver and start a session', function (done) {
+        // retry up to 3 times
         getDriver()
+            .fail(function () {
+                return getDriver()
+                    .fail(function () {
+                        return getDriver()
+                            .fail(fail);
+                    });
+            })
             .fail(fail)
             .done(done);
-    }, 15 * MINUTE);
+    }, 30 * MINUTE);
 
     describe('Specs.', function () {
         afterEach(function (done) {
@@ -291,13 +299,20 @@ describe('Camera tests iOS.', function () {
                 return driver
                     .quit()
                     .then(function () {
-                        return getDriver();
+                        return getDriver()
+                            .fail(function () {
+                                return getDriver()
+                                    .fail(function () {
+                                        return getDriver()
+                                            .fail(fail);
+                                    });
+                            });
                     })
                     .done(done);
             } else {
                 done();
             }
-        }, 15 * MINUTE);
+        }, 30 * MINUTE);
 
         // getPicture() with mediaType: VIDEO, sourceType: PHOTOLIBRARY
         it('camera.ui.spec.1 Selecting only videos', function (done) {


### PR DESCRIPTION
### Platforms affected
Android, iOS

### What does this PR do?
https://issues.apache.org/jira/browse/CB-12982
Tries harder to create a session by increasing the timeout and introducing a retry mechanic.

### What testing has been done on this change?
A couple of runs with SauceLabs concurrency meter being 5/5.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
