### PR TITLE
CB-13002: (Android, iOS) Fix occasional Appium tests failures

### DIFF
--- a/appium-tests/android/android.spec.js
+++ b/appium-tests/android/android.spec.js
@@ -115,6 +115,16 @@ describe('Camera tests Android.', function () {
         if (!options) {
             options = {};
         }
+        // assign default values
+        if (!options.hasOwnProperty('allowEdit')) {
+            options.allowEdit = true;
+        }
+        if (!options.hasOwnProperty('destinationType')) {
+            options.destinationType = cameraConstants.DestinationType.FILE_URI;
+        }
+        if (!options.hasOwnProperty('sourceType')) {
+            options.destinationType = cameraConstants.PictureSourceType.CAMERA;
+        }
 
         return driver
             .context(webviewContext)

--- a/appium-tests/ios/ios.spec.js
+++ b/appium-tests/ios/ios.spec.js
@@ -128,6 +128,16 @@ describe('Camera tests iOS.', function () {
         if (!options) {
             options = {};
         }
+        // assign defaults
+        if (!options.hasOwnProperty('allowEdit')) {
+            options.allowEdit = true;
+        }
+        if (!options.hasOwnProperty('destinationType')) {
+            options.destinationType = cameraConstants.DestinationType.FILE_URI;
+        }
+        if (!options.hasOwnProperty('sourceType')) {
+            options.destinationType = cameraConstants.PictureSourceType.CAMERA;
+        }
 
         return driver
             .context(webviewContext)


### PR DESCRIPTION
### Platforms affected
Android, iOS

### What does this PR do?
Fixes a problem in Appium tests which could lead to intermittent failures.

### What testing has been done on this change?
A couple of runs on Sauce Labs' Android 6.0 emulator.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
