### PR TITLE
feat(browser): automatically click on file input field

### DIFF
--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -26,7 +26,8 @@ function takePicture(success, error, opts) {
         capture(success, error, opts);
     } else {
         var input = document.createElement('input');
-        input.style.position = 'relative';
+        input.style.position = 'absolute';
+        input.style.top = '-999px';
         input.style.zIndex = HIGHEST_POSSIBLE_Z_INDEX;
         input.className = 'cordova-camera-select';
         input.type = 'file';
@@ -46,6 +47,14 @@ function takePicture(success, error, opts) {
         };
 
         document.body.appendChild(input);
+
+        // click on element
+        var event = new MouseEvent('click', {
+            'view': window,
+            'bubbles': true,
+            'cancelable': true
+        });
+        input.dispatchEvent(event);
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Browser

### What does this PR do?
Skip the step to load an image from file system when camera.getPicture() ought to load file from the file system (not take it from camera) 

### What testing has been done on this change?
I've run `npm test`. 
Actually, there is no test for browser platform. However these changes are used in a real project.
