### PR TITLE
Fix camera permissions bug on video streaming (WebRTC)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -68,6 +68,7 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.CAMERA" />                      
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider


### PR DESCRIPTION
Versions
Ionic 3.5.0
Cordova 7.0.1
Cordova Camera Plugin 2.4.2-dev

### Platforms affected
Android

### What does this PR do?
This fix a bug found while developing a WebRTC app using Ionic on Android 7.0 and/or Android 4.4~ when using cordova.plugins.permissions to fix the new SDK 24 rules for access to camera device stream.
Applies to the new changes for access rules for camera on Android > 7.0 (Sdk > 24).


### What testing has been done on this change?
Without this fix, the camera does work on WebRTC Applications