### PR TITLE
CB-13384: (browser) Added deprecation of video.src compatibility

### DIFF
--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -102,7 +102,11 @@ function capture (success, errorCallback, opts) {
 
     var successCallback = function (stream) {
         localMediaStream = stream;
-        video.src = window.URL.createObjectURL(localMediaStream);
+        try {
+            video.src = window.URL.createObjectURL(localMediaStream);
+        } catch (e) {
+            video.srcObject = localMediaStream;
+        }
         video.play();
 
         document.body.appendChild(parent);

--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -102,13 +102,12 @@ function capture (success, errorCallback, opts) {
 
     var successCallback = function (stream) {
         localMediaStream = stream;
-        try {
-            video.src = window.URL.createObjectURL(localMediaStream);
-        } catch (e) {
+        if ('srcObject' in video) {
             video.srcObject = localMediaStream;
+        } else {
+            video.src = window.URL.createObjectURL(localMediaStream);
         }
         video.play();
-
         document.body.appendChild(parent);
     };
 


### PR DESCRIPTION
### Platforms affected
Browser

### What does this PR do?
Updates CameraProxy.js to support video.srcObject and preserves backwards compatibility with URL.createObjectURL

### What testing has been done on this change?
Browser

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
