### PR TITLE
CB-13332: (iOS) Error When Taking Picture Missing NSPhotoLibraryAddU…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -175,6 +175,11 @@
              <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
          </config-file>
 
+         <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default=" " />
+         <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+             <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
+         </config-file>
+
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
              <string></string>
          </config-file>


### PR DESCRIPTION
…sageDescription

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Fixes issues in iOS when taking a photo where app would crash because of missing NSPhotoLibraryUsageDescription

### What testing has been done on this change?
Change was tested on an ionic app on iPhone 6s running iOS 11.


### Checklist
- [X ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
