### PR TITLE
fix for using the saveToPhotoAlbum option on iOS 11

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -175,6 +175,11 @@
              <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
          </config-file>
 
+         <preference name="PHOTOLIBRARYADD_USAGE_DESCRIPTION" default=" " />
+         <config-file target="*-Info.plist" parent="NSPhotoLibraryAddUsageDescription">
+             <string>$PHOTOLIBRARYADD_USAGE_DESCRIPTION</string>
+         </config-file>
+
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
              <string></string>
          </config-file>


### PR DESCRIPTION
iOS 11 added a new permission when trying to get write only access to
the photo library.

### Platforms affected
iOS 11

### What does this PR do?
Fixes the crash that occurs when trying to use the saveToPhotoAlbum option.

### What testing has been done on this change?
I tested my change on a iphone 7 running iOS 11.

### Checklist
- [x] [CB-13477](https://issues.apache.org/jira/browse/CB-13477) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
