### PR TITLE
CB-13415 (iOS) Importing corrupt images using the Camera plugin crashes the app

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -29,6 +29,7 @@
 #import <ImageIO/CGImageDestination.h>
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <objc/message.h>
+#import <Photos/Photos.h>
 
 #ifndef __CORDOVA_4_0_0
     #import <Cordova/NSData+Base64.h>
@@ -360,7 +361,22 @@ static NSString* toBase64(NSData* data) {
         {
             if ((options.allowsEditing == NO) && (options.targetSize.width <= 0) && (options.targetSize.height <= 0) && (options.correctOrientation == NO) && (([options.quality integerValue] == 100) || (options.sourceType != UIImagePickerControllerSourceTypeCamera))){
                 // use image unedited as requested , don't resize
-                data = UIImageJPEGRepresentation(image, 1.0);
+                  if(options.sourceType != UIImagePickerControllerSourceTypeCamera){
+                    NSURL *url = info[UIImagePickerControllerReferenceURL];
+                    PHFetchResult *result = [PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil];
+                    PHAsset *asset = [result firstObject];
+                    if (asset) {
+                        PHImageManager *manager = [PHImageManager defaultManager];
+                        PHImageRequestOptions *option = [PHImageRequestOptions alloc];
+                        option.synchronous = true;
+                        [manager requestImageDataForAsset:asset options:option resultHandler:^(NSData *imageData, NSString *dataUTI, UIImageOrientation orientation, NSDictionary *info) {
+                              data = imageData;
+                        }];
+                    }
+                }
+                else{
+                    return data = UIImageJPEGRepresentation(image, 1.0);
+                }
             } else {
                 data = UIImageJPEGRepresentation(image, [options.quality floatValue] / 100.0f);
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS


### What does this PR do?

- Does not crash the Cordova app which uses the plugin with corrupted image

### What testing has been done on this change?
Tested with cordova-ios : 4.5.4 

### Checklist
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Added automated test coverage as appropriate for this change.
