### PR TITLE
CB-13865: (IOS-Ipad) Making popover Window Size configurable using popoverOptions - imagePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ location.
 | [width] | <code>Number</code> | <code>320</code> | width, in pixels, of the screen element onto which to anchor the popover. |
 | [height] | <code>Number</code> | <code>480</code> | height, in pixels, of the screen element onto which to anchor the popover. |
 | [arrowDir] | <code>[PopoverArrowDirection](#module_Camera.PopoverArrowDirection)</code> | <code>ARROW_ANY</code> | Direction the arrow on the popover should point. |
+| [popoverWidth] | <code>Number</code> | <code>0</code> | width of the popover (0 or not specified will use apple's default width). |
+| [popoverHeight] | <code>Number</code> | <code>0</code> | height of the popover (0 or not specified will use apple's default height). |
 
 ---
 
@@ -411,13 +413,13 @@ navigator.camera.getPicture(onSuccess, onFail,
 {
     destinationType: Camera.DestinationType.FILE_URI,
     sourceType: Camera.PictureSourceType.PHOTOLIBRARY,
-    popoverOptions: new CameraPopoverOptions(300, 300, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY)
+    popoverOptions: new CameraPopoverOptions(300, 300, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY, 300, 600)
 });
 
 // Reposition the popover if the orientation changes.
 window.onorientationchange = function() {
     var cameraPopoverHandle = new CameraPopoverHandle();
-    var cameraPopoverOptions = new CameraPopoverOptions(0, 0, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY);
+    var cameraPopoverOptions = new CameraPopoverOptions(0, 0, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY, 400, 500);
     cameraPopoverHandle.setPosition(cameraPopoverOptions);
 }
 ```

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -291,6 +291,19 @@ static NSString* toBase64(NSData* data) {
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     if([navigationController isKindOfClass:[UIImagePickerController class]]){
+        
+        // If popoverWidth and popoverHeight are specified and are greater than 0, then set popover size, else use apple's default popoverSize
+        NSDictionary* options = self.pickerController.pictureOptions.popoverOptions;
+        if(options) {
+            NSInteger popoverWidth = [self integerValueForKey:options key:@"popoverWidth" defaultValue:0];
+            NSInteger popoverHeight = [self integerValueForKey:options key:@"popoverHeight" defaultValue:0];
+            if(popoverWidth > 0 && popoverHeight > 0)
+            {
+                [viewController setPreferredContentSize:CGSizeMake(popoverWidth,popoverHeight)];
+            }
+        }
+        
+        
         UIImagePickerController* cameraPicker = (UIImagePickerController*)navigationController;
 
         if(![cameraPicker.mediaTypes containsObject:(NSString*)kUTTypeImage]){

--- a/tests/ios/CDVCameraTest/CDVCameraLibTests/CameraTest.m
+++ b/tests/ios/CDVCameraTest/CDVCameraLibTests/CameraTest.m
@@ -82,7 +82,7 @@
     XCTAssertEqual(options.usesGeolocation, NO);
     
     // Set each argument, check whether they are set. different from defaults
-    popoverOptions = @{ @"x" : @1, @"y" : @2, @"width" : @3, @"height" : @4 };
+    popoverOptions = @{ @"x" : @1, @"y" : @2, @"width" : @3, @"height" : @4, @"popoverWidth": @200, @"popoverHeight": @300 };
     
     args = @[
              @(49),
@@ -127,7 +127,7 @@
     
     // Souce is Camera, and image type
     
-    popoverOptions = @{ @"x" : @1, @"y" : @2, @"width" : @3, @"height" : @4 };
+    popoverOptions = @{ @"x" : @1, @"y" : @2, @"width" : @3, @"height" : @4, @"popoverWidth": @200, @"popoverHeight": @300 };
     args = @[
              @(49),
              @(DestinationTypeDataUrl),

--- a/tests/ios/package.json
+++ b/tests/ios/package.json
@@ -8,6 +8,6 @@
         "cordova-ios": "*"
     },
     "scripts": {
-        "test": "xcodebuild -scheme CordovaLib && xcodebuild test -scheme CDVCameraLibTests -destination 'platform=iOS Simulator,name=iPhone 5'"
+        "test": "xcodebuild -scheme CordovaLib && xcodebuild test -scheme CDVCameraLibTests -destination 'platform=iOS Simulator,name=iPhone 5s'"
     }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -162,7 +162,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
 
         // Reposition the popover if the orientation changes.
         window.onorientationchange = function () {
-            var newPopoverOptions = new CameraPopoverOptions(0, 0, 100, 100, 0);
+            var newPopoverOptions = new CameraPopoverOptions(0, 0, 100, 100, 0, 300, 400);
             popoverHandle.setPosition(newPopoverOptions);
         };
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -136,6 +136,8 @@ interface CameraPopoverOptions {
      *      ARROW_ANY : 15
      */
     arrowDir : number;
+    popoverWidth: number;
+    popoverHeight: number;
 }
 
 declare var Camera: {

--- a/www/CameraPopoverOptions.js
+++ b/www/CameraPopoverOptions.js
@@ -39,14 +39,18 @@ var Camera = require('./Camera');
  * @param {Number} [width=320] - width, in pixels, of the screen element onto which to anchor the popover.
  * @param {Number} [height=480] - height, in pixels, of the screen element onto which to anchor the popover.
  * @param {module:Camera.PopoverArrowDirection} [arrowDir=ARROW_ANY] - Direction the arrow on the popover should point.
+ * @param {Number} [popoverWidth=0] - width of the popover (0 or not specified will use apple's default width).
+ * @param {Number} [popoverHeight=0] - height of the popover (0 or not specified will use apple's default height).
  */
-var CameraPopoverOptions = function (x, y, width, height, arrowDir) {
+var CameraPopoverOptions = function (x, y, width, height, arrowDir, popoverWidth, popoverHeight) {
     // information of rectangle that popover should be anchored to
     this.x = x || 0;
     this.y = y || 32;
     this.width = width || 320;
     this.height = height || 480;
     this.arrowDir = arrowDir || Camera.PopoverArrowDirection.ARROW_ANY;
+    this.popoverWidth = popoverWidth || 0;
+    this.popoverHeight = popoverHeight || 0;
 };
 
 module.exports = CameraPopoverOptions;

--- a/www/ios/CameraPopoverHandle.js
+++ b/www/ios/CameraPopoverHandle.js
@@ -37,13 +37,13 @@ var exec = require('cordova/exec');
  * {
  *     destinationType: Camera.DestinationType.FILE_URI,
  *     sourceType: Camera.PictureSourceType.PHOTOLIBRARY,
- *     popoverOptions: new CameraPopoverOptions(300, 300, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY)
+ *     popoverOptions: new CameraPopoverOptions(300, 300, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY, 300, 600)
  * });
  *
  * // Reposition the popover if the orientation changes.
  * window.onorientationchange = function() {
  *     var cameraPopoverHandle = new CameraPopoverHandle();
- *     var cameraPopoverOptions = new CameraPopoverOptions(0, 0, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY);
+ *     var cameraPopoverOptions = new CameraPopoverOptions(0, 0, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY, 400, 500);
  *     cameraPopoverHandle.setPosition(cameraPopoverOptions);
  * }
  * @module CameraPopoverHandle


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
IOS - Ipad only

### What does this PR do?
Allow the user to set the popover Width and Height on Ipads

### What testing has been done on this change?
Modified the automated test cases to accommodate for the change.
Tested the plugin on the Ipad with different popover height and width as well as not specifying any.

### Checklist
- [x ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ x] Added automated test coverage as appropriate for this change.
