### PR TITLE
CB-14082: (iOS) Dismiss camera popover on permission denied

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -179,6 +179,22 @@ static NSString* toBase64(NSData* data) {
                                       cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                       otherButtonTitles:settingsButton, nil] show];
                 });
+            } else if (authStatus == AVAuthorizationStatusNotDetermined){
+                [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted)
+                 {
+                     if(!granted)
+                     {
+                         // Dismiss the view
+                         [[self.pickerController presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+
+                         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to camera"];   // error callback expects string ATM
+
+                         [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
+
+                         self.hasPendingOperation = NO;
+                         self.pickerController = nil;
+                     }
+                 }];
             }
         }
 


### PR DESCRIPTION
### Platforms affected
IOS

### What does this PR do?
It dismisses the camera popover automatically when the permission for camera usage is denied

### What testing has been done on this change?
Used the patched version of the plugin in a iOS application going through all the cases of accepting/denying permissions

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.