### PR TITLE
GH-329: (android) Fixes issue: Exif data lost on many cases

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -994,6 +994,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                         // read exifData of source
                         exifData = new ExifHelper();
                         exifData.createInFile(filePath);
+                        exif.readExifData();
                         // Use ExifInterface to pull rotation information
                         if (this.correctOrientation) {
                             ExifInterface exif = new ExifInterface(filePath);

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -994,7 +994,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                         // read exifData of source
                         exifData = new ExifHelper();
                         exifData.createInFile(filePath);
-                        exif.readExifData();
+                        exifData.readExifData();
                         // Use ExifInterface to pull rotation information
                         if (this.correctOrientation) {
                             ExifInterface exif = new ExifInterface(filePath);


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Reads the exif data from the file on these cases:
-When destType = DATA_URL
-When file is selected from gallery.
-When targetHeight or targetWidth is set, quality is not 100 or correctOrientation is true

### What testing has been done on this change?
Tested on two differente android devices.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

---
closes #329