### PR TITLE
fix(android): Prevent ClassNotFoundException if applicationId is not same as manifest package name

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -141,9 +141,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      */
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         this.callbackContext = callbackContext;
-        //Adding an API to CoreAndroid to get the BuildConfigValue
-        //This allows us to not make this a breaking change to embedding
-        this.applicationId = (String) BuildHelper.getBuildConfigValue(cordova.getActivity(), "APPLICATION_ID");
+        // Reference to BuildHelper provokes ClassNotFoundException if applicationId is not same
+        // as manifest package name (this will be case for example if ".debug" has been appended
+        // to applicationId in build-extras.gradle.)
+        // Here we only need the applicationId. As Context.getPackageName() returns the applicationId and
+        // not the package name (despite documentation for Context class) we can use the value returned by
+        // getPackageName directly. See note on applicationId in:
+        //   https://developer.android.com/studio/build/application-id
+        this.applicationId = cordova.getContext().getPackageName();
         this.applicationId = preferences.getString("applicationId", this.applicationId);
 
 


### PR DESCRIPTION
### Platforms affected
android

### What does this PR do?
Prevent ClassNotFoundException when applicationid not same as manifest package name

### What testing has been done on this change?
Tested locally on Nexus 5x. 


### Checklist
- [x ] [Reported an issue](https://github.com/apache/cordova-android/issues/513) in the JIRA database
- [x ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
Commit message: CH-513: (android) Prevent ClassNotFoundException
(issue #513 created in Github, not JIRA.)
- [x ] Added automated test coverage as appropriate for this change.
No tests added.

Pull request created at request of user @janpio