### PR TITLE
CB-13837: fix TypeScript Definition for CameraPopoverOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -138,6 +138,10 @@ interface CameraPopoverOptions {
     arrowDir : number;
 }
 
+declare class CameraPopoverOptions implements CameraPopoverOptions {
+    constructor(x?: number, y?: number, width?: number, height?: number, arrowDir?: number);
+}
+
 declare var Camera: {
     // Camera constants, defined in Camera plugin
     DestinationType: {


### PR DESCRIPTION

### Platforms affected
all

### What does this PR do?
Fix TypeScript Definition for CameraPopoverOptions

### What testing has been done on this change?
Used in a TypeScript project and see that linter didn't complain after the change

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
