### PR TITLE
Update CI Environment Setup for Node.js 6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ image:
   - Visual Studio 2017
 
 environment:
-  nodejs_version: "4"
+  nodejs_version: "6"
   matrix:
     - PLATFORM: windows-10-store
       JUST_BUILD: --justBuild

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,16 +13,16 @@ image:
 
 environment:
   nodejs_version: "6"
+
   matrix:
     - PLATFORM: windows-10-store
-      JUST_BUILD: --justBuild
+
 install:
-  - npm cache clean -f
   - node --version
-  - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
+  - npm install -g github:apache/cordova-paramedic
   - npm install -g cordova
 
 build: off
 
 test_script:
-  - cordova-paramedic --config pr\%PLATFORM% --plugin . %JUST_BUILD%
+  - cordova-paramedic --config pr\%PLATFORM% --plugin . --justBuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+
 addons:
   jwt:
     secure: QivPLlqTVvOo3TJeHxuBOfxU6lho1I0IxQ3b68yntkEQQJko6kzleXHfgjf0a8aw8m38E3+fxaBWF1bGyucGwOLDWY8Ddt2P2xg44zdXH5EXHd9oIqAgngIdzLvUtH3Db2TbQEtIGOkrnNR2STovjqB7vHGLASQrgs4oL7r32/s=
+
 env:
   global:
   - SAUCE_USERNAME=snay
@@ -14,72 +16,56 @@ matrix:
   include:
   - env: TEST_DIR=.
     language: objective-c
+
   - env: TEST_DIR=./tests/ios
     language: objective-c
+
   - env: PLATFORM=browser-chrome
-    os: linux
   - env: PLATFORM=browser-firefox
-    os: linux
   - env: PLATFORM=browser-safari
-    os: linux
   - env: PLATFORM=browser-edge
-    os: linux
-  - env: PLATFORM=ios-9.3
-    os: osx
-    osx_image: xcode9
+
   - env: PLATFORM=ios-10.0
     os: osx
     osx_image: xcode9
-  - env: PLATFORM=android-4.4
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - extra-android-m2repository
-      - build-tools-28.0.2
-  - env: PLATFORM=android-5.1
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - extra-android-m2repository
-      - build-tools-28.0.2
-  - env: PLATFORM=android-6.0
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - extra-android-m2repository
-      - build-tools-28.0.2
+
   - env: PLATFORM=android-7.0
     os: linux
     language: android
     jdk: oraclejdk8
     android:
       components:
-      - tools
-      - extra-android-m2repository
-      - build-tools-28.0.2
+        - tools
+        - build-tools-28.0.3
+        - android-28
+        - extra-android-m2repository
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
+        - 'google-gdk-license-.+'
+
 before_install:
-# `language: android` has no Node.js installed, therefore we need to install it manually
-- if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi
-- if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
-- if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
-- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27,android-28; fi
-- git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic&& npm install && popd
-- npm install -g cordova
+  # `language: android` has no Node.js installed, therefore we need to install it manually
+  - if [[ "$PLATFORM" =~ android ]]; then
+      nvm install $TRAVIS_NODE_VERSION;
+      gradle --version;
+    fi
+
+  - if [[ "$PLATFORM" =~ ios ]]; then
+      npm install -g ios-deploy;
+    fi
+
+  - npm install -g github:apache/cordova-paramedic
+  - npm install -g cordova
+
 install:
-- npm install
+  - npm install
+
 script:
-- if [[ "$TEST_DIR" != "" ]];
-  then cd $TEST_DIR && npm install && npm test;
-  else
-  node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
-  --buildName travis-plugin-camera-$TRAVIS_JOB_NUMBER;
-  fi
+  - if [[ "$TEST_DIR" != "" ]]; then
+      cd $TEST_DIR;
+      npm install;
+      npm test;
+    else
+      cordova-paramedic --config pr/$PLATFORM --plugin . --shouldUseSauce --buildName travis-plugin-camera-$TRAVIS_JOB_NUMBER;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ addons:
 env:
   global:
   - SAUCE_USERNAME=snay
-  - TRAVIS_NODE_VERSION="4.2"
+  - TRAVIS_NODE_VERSION=6
+
+language: node_js
+node_js: 6
+
 matrix:
   include:
   - env: TEST_DIR=.
@@ -14,30 +18,18 @@ matrix:
     language: objective-c
   - env: PLATFORM=browser-chrome
     os: linux
-    language: node_js
-    node_js: '4.2'
   - env: PLATFORM=browser-firefox
     os: linux
-    language: node_js
-    node_js: '4.2'
   - env: PLATFORM=browser-safari
     os: linux
-    language: node_js
-    node_js: '4.2'
   - env: PLATFORM=browser-edge
     os: linux
-    language: node_js
-    node_js: '4.2'
   - env: PLATFORM=ios-9.3
     os: osx
-    osx_image: xcode7.3
-    language: node_js
-    node_js: "4.2"
+    osx_image: xcode9
   - env: PLATFORM=ios-10.0
     os: osx
-    osx_image: xcode7.3
-    language: node_js
-    node_js: "4.2"
+    osx_image: xcode9
   - env: PLATFORM=android-4.4
     os: linux
     language: android
@@ -46,7 +38,7 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
-      - build-tools-26.0.2
+      - build-tools-28.0.2
   - env: PLATFORM=android-5.1
     os: linux
     language: android
@@ -55,7 +47,7 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
-      - build-tools-26.0.2
+      - build-tools-28.0.2
   - env: PLATFORM=android-6.0
     os: linux
     language: android
@@ -64,7 +56,7 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
-      - build-tools-26.0.2
+      - build-tools-28.0.2
   - env: PLATFORM=android-7.0
     os: linux
     language: android
@@ -73,16 +65,14 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
-      - build-tools-26.0.2
+      - build-tools-28.0.2
 before_install:
-- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
-- node --version
+# `language: android` has no Node.js installed, therefore we need to install it manually
+- if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi
 - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
 - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
-- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27;
-  fi
-- git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic
-  && npm install && popd
+- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27; fi
+- git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic&& npm install && popd
 - npm install -g cordova
 install:
 - npm install
@@ -93,4 +83,3 @@ script:
   node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
   --buildName travis-plugin-camera-$TRAVIS_JOB_NUMBER;
   fi
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ before_install:
 - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi
 - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
 - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
-- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27; fi
+- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27,android-28; fi
 - git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic&& npm install && popd
 - npm install -g cordova
 install:


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`Node.js 4` is officially out of active LTS. However, it was still used `node.js 4` in the `Travis CI` and `AppVeyor`. This causes some builds to fail.

### Description
<!-- Describe your changes in detail -->

Update `Travis CI` and `AppVeyor` configuration files to use `node.js 6`. Also, update the `iOS` platform to use `xcode9` and `android` to use `build-tools-28.0.2`, because in the `paramedic` we already use newer versions.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
