### PR TITLE
(ios) Fix mainthread issue on UIImagePickerController

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -182,16 +182,18 @@ static NSString* toBase64(NSData* data) {
             }
         }
 
-        CDVCameraPicker* cameraPicker = [CDVCameraPicker createFromPictureOptions:pictureOptions];
-        weakSelf.pickerController = cameraPicker;
-        
-        cameraPicker.delegate = weakSelf;
-        cameraPicker.callbackId = command.callbackId;
-        // we need to capture this state for memory warnings that dealloc this object
-        cameraPicker.webView = weakSelf.webView;
-        
+       
         // Perform UI operations on the main thread
         dispatch_async(dispatch_get_main_queue(), ^{
+
+            CDVCameraPicker* cameraPicker = [CDVCameraPicker createFromPictureOptions:pictureOptions];
+            weakSelf.pickerController = cameraPicker;
+            
+            cameraPicker.delegate = weakSelf;
+            cameraPicker.callbackId = command.callbackId;
+            // we need to capture this state for memory warnings that dealloc this object
+            cameraPicker.webView = weakSelf.webView;
+                
             // If a popover is already open, close it; we only want one at a time.
             if (([[weakSelf pickerController] pickerPopoverController] != nil) && [[[weakSelf pickerController] pickerPopoverController] isPopoverVisible]) {
                 [[[weakSelf pickerController] pickerPopoverController] dismissPopoverAnimated:YES];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
iOS13 compatibility issue



### Description

Main Thread Checker: UI API called on a background thread: -[UIImagePickerController init]



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
