### PR TITLE
fix(camera): resultForVideo uri in iOS13

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -512,8 +512,17 @@ static NSString* toBase64(NSData* data) {
 
 - (CDVPluginResult*)resultForVideo:(NSDictionary*)info
 {
-    NSString* moviePath = [[info objectForKey:UIImagePickerControllerMediaURL] absoluteString];
-    return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:moviePath];
+    NSString* moviePath = [[info objectForKey:UIImagePickerControllerMediaURL] path];
+
+    NSArray* spliteArray = [moviePath componentsSeparatedByString: @"/"];
+    NSString* lastString = [spliteArray lastObject];
+    NSError *error;
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *documentsDirectory = [NSHomeDirectory() stringByAppendingPathComponent:@"tmp"];
+    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:lastString];
+    [fileManager copyItemAtPath:moviePath toPath:filePath error:&error];
+
+    return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:filePath];
 }
 
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingMediaWithInfo:(NSDictionary*)info

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -514,12 +514,14 @@ static NSString* toBase64(NSData* data) {
 {
     NSString* moviePath = [[info objectForKey:UIImagePickerControllerMediaURL] path];
 
-    NSArray* spliteArray = [moviePath componentsSeparatedByString: @"/"];
-    NSString* lastString = [spliteArray lastObject];
+    NSArray* moviePathParts = [moviePath componentsSeparatedByString: @"/"];
+    NSString* fileName = [moviePathParts lastObject];    
+
+    NSString *cachesDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
+    NSString *filePath = [cachesDirectory stringByAppendingPathComponent:fileName];
+
     NSError *error;
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSString *documentsDirectory = [NSHomeDirectory() stringByAppendingPathComponent:@"tmp"];
-    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:lastString];
     [fileManager copyItemAtPath:moviePath toPath:filePath error:&error];
 
     return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:filePath];


### PR DESCRIPTION
In iOS 13, videos' uris are not being retrieved properly as this issue describes: https://github.com/apache/cordova-plugin-camera/issues/506#issue-496782771

Closes #506 

### Platforms affected

iOS

### Motivation and Context

This PR aims to solve that bug ir order for the plugin to retrieve the file's uri properly. Full credit for this solution to https://github.com/apache/cordova-plugin-camera/issues/506#issuecomment-534070130.



### Description
Please see https://github.com/apache/cordova-plugin-camera/issues/506#issue-496782771



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
