### PR TITLE
fix(android): file path correction if Uri authority is FileProvider

### DIFF
--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -355,5 +355,4 @@ public class FileHelper {
         return file.exists() ? file.toString(): null;
     }
 
-
 }

--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -19,7 +19,6 @@ package org.apache.cordova.camera;
 import android.annotation.SuppressLint;
 import android.content.ContentUris;
 import android.content.Context;
-import android.content.CursorLoader;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
@@ -29,8 +28,8 @@ import android.provider.MediaStore;
 import android.webkit.MimeTypeMap;
 
 import org.apache.cordova.CordovaInterface;
-import org.apache.cordova.LOG;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,7 +43,7 @@ public class FileHelper {
      * Returns the real path of the given URI string.
      * If the given URI string represents a content:// URI, the real path is retrieved from the media store.
      *
-     * @param uriString the URI string of the audio/image/video
+     * @param uri the URI of the audio/image/video
      * @param cordova the current application context
      * @return the full path to the file
      */
@@ -66,7 +65,7 @@ public class FileHelper {
      * Returns the real path of the given URI.
      * If the given URI is a content:// URI, the real path is retrieved from the media store.
      *
-     * @param uri the URI of the audio/image/video
+     * @param uriString the URI string from which to obtain the input stream
      * @param cordova the current application context
      * @return the full path to the file
      */
@@ -143,6 +142,9 @@ public class FileHelper {
             if (isGooglePhotosUri(uri))
                 return uri.getLastPathSegment();
 
+            if (isFileProviderUri(context, uri))
+                return getFileProviderPath(context, uri);
+
             return getDataColumn(context, uri, null, null);
         }
         // File
@@ -188,6 +190,7 @@ public class FileHelper {
             if (question > -1) {
                 uriString = uriString.substring(0, question);
             }
+
             if (uriString.startsWith("file:///android_asset/")) {
                 Uri uri = Uri.parse(uriString);
                 String relativePath = uri.getPath().substring(15);
@@ -217,6 +220,7 @@ public class FileHelper {
      * @return a path without the "file://" prefix
      */
     public static String stripFileProtocol(String uriString) {
+
         if (uriString.startsWith("file://")) {
             uriString = uriString.substring(7);
         }
@@ -327,4 +331,29 @@ public class FileHelper {
     public static boolean isGooglePhotosUri(Uri uri) {
         return "com.google.android.apps.photos.content".equals(uri.getAuthority());
     }
+
+    /**
+     * @param context The Application context
+     * @param uri The Uri is checked by functions
+     * @return Whether the Uri authority is FileProvider
+     */
+    public static boolean isFileProviderUri(final Context context, final Uri uri) {
+        final String packageName = context.getPackageName();
+        final String authority = new StringBuilder(packageName).append(".provider").toString();
+        return authority.equals(uri.getAuthority());
+    }
+
+    /**
+     * @param context The Application context
+     * @param uri The Uri is checked by functions
+     * @return File path or null if file is missing
+     */
+    public static String getFileProviderPath(final Context context, final Uri uri)
+    {
+        final File appDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        final File file = new File(appDir, uri.getLastPathSegment());
+        return file.exists() ? file.toString(): null;
+    }
+
+
 }


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
Select some videos or images return path error when Uri authority is FileProvider, then the app restarts.. That's why this bug is not always happening but it can be really annoying.

It's probably fixing the following issues (hard to say some descriptions are rather short): Resolves #573, resolves #531, resolves #548, resolves #554, resolves #558, resolves #563 


### Description
Checking if Uri authority is FileProvider for MediaStore content then find the URI.


### Testing
Tested with most of my user's app and with my **Huawei p smart 2019 - Android 10** and with Samsung Galaxy S5.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
