### PR TITLE
(ios)call 'showCameraPicker' on main thread

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -174,11 +174,15 @@ static NSString* toBase64(NSData* data) {
                          [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
                      });
                  } else {
-                     [weakSelf showCameraPicker:command.callbackId withOptions:pictureOptions];
+                     dispatch_async(dispatch_get_main_queue(), ^{
+                         [weakSelf showCameraPicker:command.callbackId withOptions:pictureOptions];
+                     });
                  }
              }];
         } else {
-            [weakSelf showCameraPicker:command.callbackId withOptions:pictureOptions];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [weakSelf showCameraPicker:command.callbackId withOptions:pictureOptions];
+            });
         }
     }];
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix UI API called on a background thread


### Description
<!-- Describe your changes in detail -->
put code inside main queue
dispatch_async(dispatch_get_main_queue(), ^{
});


### Testing
<!-- Please describe in detail how you tested your changes. -->
start to use plugin and no warning anymore


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
