### PR TITLE
breaking: remove NATIVE_URI DestinationType

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,19 +276,14 @@ Optional parameters to customize the camera settings.
 
 ### Camera.DestinationType : <code>enum</code>
 Defines the output format of `Camera.getPicture` call.
-_Note:_ On iOS passing `DestinationType.NATIVE_URI` along with
-`PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM` will
-disable any image modifications (resize, quality change, cropping, etc.) due
-to implementation specific.
 
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| DATA_URL | <code>number</code> | <code>0</code> | Return base64 encoded string. DATA_URL can be very memory intensive and cause app crashes or out of memory errors. Use FILE_URI or NATIVE_URI if possible |
+| DATA_URL | <code>number</code> | <code>0</code> | Return base64 encoded string. DATA_URL can be very memory intensive and cause app crashes or out of memory errors. Use FILE_URI if possible |
 | FILE_URI | <code>number</code> | <code>1</code> | Return file uri (content://media/external/images/media/2 for Android) |
-| NATIVE_URI | <code>number</code> | <code>2</code> | Return native uri (eg. asset-library://... for iOS) |
 
 <a name="module_Camera.EncodingType"></a>
 
@@ -317,9 +312,6 @@ to implementation specific.
 
 ### Camera.PictureSourceType : <code>enum</code>
 Defines the output format of `Camera.getPicture` call.
-_Note:_ On iOS passing `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM`
-along with `DestinationType.NATIVE_URI` will disable any image modifications (resize, quality
-change, cropping, etc.) due to implementation specific.
 
 **Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
 **Properties**
@@ -435,7 +427,7 @@ Take a photo and retrieve it as a Base64-encoded image:
      * Warning: Using DATA_URL is not recommended! The DATA_URL destination
      * type is very memory intensive, even with a low quality setting. Using it
      * can result in out of memory errors and application crashes. Use FILE_URI
-     * or NATIVE_URI instead.
+     * instead.
      */
     navigator.camera.getPicture(onSuccess, onFail, { quality: 25,
         destinationType: Camera.DestinationType.DATA_URL
@@ -508,9 +500,6 @@ More information about Windows Phone 8.1 picker APIs is here: [How to continue y
 
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory. The contents of the application's temporary directory is deleted when the application ends.
 
-- When using `destinationType.NATIVE_URI` and `sourceType.CAMERA`, photos are saved in the saved photo album regardless on the value of `saveToPhotoAlbum` parameter.
-
-- When using `destinationType.NATIVE_URI` and `sourceType.PHOTOLIBRARY` or `sourceType.SAVEDPHOTOALBUM`, all editing options are ignored and link is returned to original picture.
 
 [android_lifecycle]: http://cordova.apache.org/docs/en/dev/guide/platforms/android/lifecycle.html
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-dev",
+  "version": "5.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -69,7 +69,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
     private static final int DATA_URL = 0;              // Return base64 encoded string
     private static final int FILE_URI = 1;              // Return file uri (content://media/external/images/media/2 for Android)
-    private static final int NATIVE_URI = 2;                    // On Android, this is the same as FILE_URI
 
     private static final int PHOTOLIBRARY = 0;          // Choose image from picture library (same as SAVEDPHOTOALBUM for Android)
     private static final int CAMERA = 1;                // Take picture from camera
@@ -532,7 +531,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
 
         // If sending filename back
-        else if (destType == FILE_URI || destType == NATIVE_URI) {
+        else if (destType == FILE_URI) {
             // If all this is true we shouldn't compress the image.
             if (this.targetHeight == -1 && this.targetWidth == -1 && this.mQuality == 100 &&
                     !this.correctOrientation) {
@@ -703,7 +702,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 // This is a special case to just return the path as no scaling,
                 // rotating, nor compressing needs to be done
                 if (this.targetHeight == -1 && this.targetWidth == -1 &&
-                        (destType == FILE_URI || destType == NATIVE_URI) && !this.correctOrientation &&
+                        destType == FILE_URI && !this.correctOrientation &&
                         mimeType != null && mimeType.equalsIgnoreCase(getMimetypeForFormat(encodingType)))
                 {
                     this.callbackContext.success(finalLocation);
@@ -726,7 +725,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     }
 
                     // If sending filename back
-                    else if (destType == FILE_URI || destType == NATIVE_URI) {
+                    else if (destType == FILE_URI) {
                         // Did we modify the image?
                         if ( (this.targetHeight > 0 && this.targetWidth > 0) ||
                                 (this.correctOrientation && this.orientationCorrected) ||

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -24,8 +24,7 @@
 
 enum CDVDestinationType {
     DestinationTypeDataUrl = 0,
-    DestinationTypeFileUri,
-    DestinationTypeNativeUri
+    DestinationTypeFileUri
 };
 typedef NSUInteger CDVDestinationType;
 

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -168,7 +168,7 @@ static NSString* toBase64(NSData* data) {
                              [weakSelf sendNoPermissionResult:command.callbackId];
                          }]];
                          [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                             [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+                             [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString] options:@{} completionHandler:nil];
                              [weakSelf sendNoPermissionResult:command.callbackId];
                          }]];
                          [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
@@ -440,33 +440,16 @@ static NSString* toBase64(NSData* data) {
     UIImage* image = nil;
 
     switch (options.destinationType) {
-        case DestinationTypeNativeUri:
+        case DestinationTypeDataUrl:
         {
-            NSURL* url = [info objectForKey:UIImagePickerControllerReferenceURL];
-            saveToPhotoAlbum = NO;
-            // If, for example, we use sourceType = Camera, URL might be nil because image is stored in memory.
-            // In this case we must save image to device before obtaining an URI.
-            if (url == nil) {
-                image = [self retrieveImage:info options:options];
-                ALAssetsLibrary* library = [ALAssetsLibrary new];
-                [library writeImageToSavedPhotosAlbum:image.CGImage orientation:(ALAssetOrientation)(image.imageOrientation) completionBlock:^(NSURL *assetURL, NSError *error) {
-                    CDVPluginResult* resultToReturn = nil;
-                    if (error) {
-                        resultToReturn = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsString:[error localizedDescription]];
-                    } else {
-                        NSString* nativeUri = [[self urlTransformer:assetURL] absoluteString];
-                        resultToReturn = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nativeUri];
-                    }
-                    completion(resultToReturn);
-                }];
-                return;
-            } else {
-                NSString* nativeUri = [[self urlTransformer:url] absoluteString];
-                result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:nativeUri];
+            image = [self retrieveImage:info options:options];
+            NSData* data = [self processImage:image info:info options:options];
+            if (data)  {
+                result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:toBase64(data)];
             }
         }
             break;
-        case DestinationTypeFileUri:
+        default: // DestinationTypeFileUri
         {
             image = [self retrieveImage:info options:options];
             NSData* data = [self processImage:image info:info options:options];
@@ -485,22 +468,10 @@ static NSString* toBase64(NSData* data) {
             }
         }
             break;
-        case DestinationTypeDataUrl:
-        {
-            image = [self retrieveImage:info options:options];
-            NSData* data = [self processImage:image info:info options:options];
-            if (data)  {
-                result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:toBase64(data)];
-            }
-        }
-            break;
-        default:
-            break;
     };
 
     if (saveToPhotoAlbum && image) {
-        ALAssetsLibrary* library = [ALAssetsLibrary new];
-        [library writeImageToSavedPhotosAlbum:image.CGImage orientation:(ALAssetOrientation)(image.imageOrientation) completionBlock:nil];
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);
     }
 
     completion(result);
@@ -576,10 +547,8 @@ static NSString* toBase64(NSData* data) {
 
     dispatch_block_t invoke = ^ (void) {
         CDVPluginResult* result;
-        if (picker.sourceType == UIImagePickerControllerSourceTypeCamera && [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] != ALAuthorizationStatusAuthorized) {
+        if (picker.sourceType == UIImagePickerControllerSourceTypeCamera && [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] != AVAuthorizationStatusAuthorized) {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to camera"];
-        } else if (picker.sourceType != UIImagePickerControllerSourceTypeCamera && ! IsAtLeastiOSVersion(@"11.0") && [ALAssetsLibrary authorizationStatus] != ALAuthorizationStatusAuthorized) {
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to assets"];
         } else {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No Image Selected"];
         }
@@ -694,7 +663,12 @@ static NSString* toBase64(NSData* data) {
     }
 
     switch (options.destinationType) {
-        case DestinationTypeFileUri:
+        case DestinationTypeDataUrl:
+        {
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:toBase64(self.data)];
+        }
+            break;
+        default: // DestinationTypeFileUri
         {
             NSError* err = nil;
             NSString* extension = self.pickerController.pictureOptions.encodingType == EncodingTypePNG ? @"png":@"jpg";
@@ -709,14 +683,6 @@ static NSString* toBase64(NSData* data) {
             }
         }
             break;
-        case DestinationTypeDataUrl:
-        {
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:toBase64(self.data)];
-        }
-            break;
-        case DestinationTypeNativeUri:
-        default:
-            break;
     };
 
     if (result) {
@@ -729,8 +695,7 @@ static NSString* toBase64(NSData* data) {
     self.metadata = nil;
 
     if (options.saveToPhotoAlbum) {
-        ALAssetsLibrary *library = [ALAssetsLibrary new];
-        [library writeImageDataToSavedPhotosAlbum:self.data metadata:self.metadata completionBlock:nil];
+        UIImageWriteToSavedPhotosAlbum([[UIImage alloc] initWithData:self.data], nil, nil, nil);
     }
 }
 

--- a/src/osx/CDVCamera.h
+++ b/src/osx/CDVCamera.h
@@ -24,8 +24,7 @@
 
 enum CDVDestinationType {
     DestinationTypeDataUrl = 0,
-    DestinationTypeFileUri,
-    DestinationTypeNativeUri
+    DestinationTypeFileUri
 };
 typedef NSUInteger CDVDestinationType;
 

--- a/src/osx/CDVCamera.m
+++ b/src/osx/CDVCamera.m
@@ -161,7 +161,7 @@ static NSMutableArray *cleanUpFiles;
 
 /*!
  Returns to JavaScript a URI.
- Called when Camera.DestinationType.FILE_URI or Camera.DestinationType.NATIVE_URI.
+ Called when Camera.DestinationType.FILE_URI.
  */
 - (void)returnUri:(NSString *)path command:(CDVInvokedUrlCommand *)command options:(CDVPictureOptions *)pictureOptions {
     NSString *protocol = (pictureOptions.destinationType == DestinationTypeFileUri) ? @"file://" : @"";

--- a/src/windows/CameraProxy.js
+++ b/src/windows/CameraProxy.js
@@ -190,17 +190,13 @@ function takePictureFromFileWP (successCallback, errorCallback, args) {
                 webUIApp.removeEventListener('activated', filePickerActivationHandler);
                 return;
             }
-            if (destinationType === Camera.DestinationType.FILE_URI || destinationType === Camera.DestinationType.NATIVE_URI) {
+            if (destinationType === Camera.DestinationType.FILE_URI) {
                 if (targetHeight > 0 && targetWidth > 0) {
                     resizeImage(successCallback, errorCallback, file, targetWidth, targetHeight, encodingType);
                 } else {
                     var storageFolder = getAppData().localFolder;
                     file.copyAsync(storageFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting).done(function (storageFile) {
-                        if (destinationType === Camera.DestinationType.NATIVE_URI) {
-                            successCallback('ms-appdata:///local/' + storageFile.name);
-                        } else {
-                            successCallback(URL.createObjectURL(storageFile));
-                        }
+                        successCallback(URL.createObjectURL(storageFile));
                     }, function () {
                         errorCallback("Can't access localStorage folder.");
                     });
@@ -259,17 +255,13 @@ function takePictureFromFileWindows (successCallback, errorCallback, args) {
             errorCallback("User didn't choose a file.");
             return;
         }
-        if (destinationType === Camera.DestinationType.FILE_URI || destinationType === Camera.DestinationType.NATIVE_URI) {
+        if (destinationType === Camera.DestinationType.FILE_URI) {
             if (targetHeight > 0 && targetWidth > 0) {
                 resizeImage(successCallback, errorCallback, file, targetWidth, targetHeight, encodingType);
             } else {
                 var storageFolder = getAppData().localFolder;
                 file.copyAsync(storageFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting).done(function (storageFile) {
-                    if (destinationType === Camera.DestinationType.NATIVE_URI) {
-                        successCallback('ms-appdata:///local/' + storageFile.name);
-                    } else {
-                        successCallback(URL.createObjectURL(storageFile));
-                    }
+                    successCallback(URL.createObjectURL(storageFile));
                 }, function () {
                     errorCallback("Can't access localStorage folder.");
                 });
@@ -779,7 +771,7 @@ function takePictureFromCameraWindows (successCallback, errorCallback, args) {
 function savePhoto (picture, options, successCallback, errorCallback) {
     // success callback for capture operation
     var success = function (picture) {
-        if (options.destinationType === Camera.DestinationType.FILE_URI || options.destinationType === Camera.DestinationType.NATIVE_URI) {
+        if (options.destinationType === Camera.DestinationType.FILE_URI) {
             if (options.targetHeight > 0 && options.targetWidth > 0) {
                 resizeImage(successCallback, errorCallback, picture, options.targetWidth, options.targetHeight, options.encodingType);
             } else {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -42,10 +42,8 @@ exports.defineAutoTests = function () {
         it('camera.spec.2 should contain three DestinationType constants', function () {
             expect(Camera.DestinationType.DATA_URL).toBe(0);
             expect(Camera.DestinationType.FILE_URI).toBe(1);
-            expect(Camera.DestinationType.NATIVE_URI).toBe(2);
             expect(navigator.camera.DestinationType.DATA_URL).toBe(0);
             expect(navigator.camera.DestinationType.FILE_URI).toBe(1);
-            expect(navigator.camera.DestinationType.NATIVE_URI).toBe(2);
         });
 
         it('camera.spec.3 should contain two EncodingType constants', function () {
@@ -140,7 +138,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     function getPictureWin (data) {
         setPicture(data);
         // TODO: Fix resolveLocalFileSystemURI to work with native-uri.
-        if (pictureUrl.indexOf('file:') === 0 || pictureUrl.indexOf('content:') === 0 || pictureUrl.indexOf('ms-appdata:') === 0 || pictureUrl.indexOf('assets-library:') === 0) {
+        if (pictureUrl.indexOf('file:') === 0 || pictureUrl.indexOf('content:') === 0) {
             resolveLocalFileSystemURL(data, function (e) {
                 fileEntry = e;
                 logCallback('resolveLocalFileSystemURL()', true)(e.toURL());
@@ -174,7 +172,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     }
 
     /**
-     * Select image from library using a NATIVE_URI destination type
+     * Select image from library
      * This calls FileEntry.getMetadata, FileEntry.setMetadata, FileEntry.getParent, FileEntry.file, and FileReader.readAsDataURL.
      */
     function readFile () {
@@ -217,7 +215,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     }
 
     /**
-     * Copy image from library using a NATIVE_URI destination type
+     * Copy image from library
      * This calls FileEntry.copyTo and FileEntry.moveTo.
      */
     function copyImage () {
@@ -251,7 +249,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     }
 
     /**
-     * Write image to library using a NATIVE_URI destination type
+     * Write image to library
      * This calls FileEntry.createWriter, FileWriter.write, and FileWriter.truncate.
      */
     function writeImage () {
@@ -285,7 +283,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     }
 
     /**
-     * Remove image from library using a NATIVE_URI destination type
+     * Remove image from library
      * This calls FileEntry.remove.
      */
     function removeImage () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,8 +51,6 @@ interface CameraOptions {
      * Defined in navigator.camera.DestinationType. Default is FILE_URI.
      *      DATA_URL : 0,   Return image as base64-encoded string
      *      FILE_URI : 1,   Return image file URI
-     *      NATIVE_URI : 2  Return image native URI
-     *          (e.g., assets-library:// on iOS or content:// on Android)
      */
     destinationType?: number;
     /**
@@ -149,7 +147,6 @@ declare var Camera: {
     DestinationType: {
         DATA_URL: number;
         FILE_URI: number;
-        NATIVE_URI: number
     }
     Direction: {
         BACK: number;

--- a/www/CameraConstants.js
+++ b/www/CameraConstants.js
@@ -26,20 +26,14 @@ module.exports = {
     /**
      * @description
      * Defines the output format of `Camera.getPicture` call.
-     * _Note:_ On iOS passing `DestinationType.NATIVE_URI` along with
-     * `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM` will
-     * disable any image modifications (resize, quality change, cropping, etc.) due
-     * to implementation specific.
      *
      * @enum {number}
      */
     DestinationType: {
-        /** Return base64 encoded string. DATA_URL can be very memory intensive and cause app crashes or out of memory errors. Use FILE_URI or NATIVE_URI if possible */
+        /** Return base64 encoded string. DATA_URL can be very memory intensive and cause app crashes or out of memory errors. Use FILE_URI if possible */
         DATA_URL: 0,
         /** Return file uri (content://media/external/images/media/2 for Android) */
-        FILE_URI: 1,
-        /** Return native uri (eg. asset-library://... for iOS) */
-        NATIVE_URI: 2
+        FILE_URI: 1
     },
     /**
      * @enum {number}
@@ -64,9 +58,6 @@ module.exports = {
     /**
      * @description
      * Defines the output format of `Camera.getPicture` call.
-     * _Note:_ On iOS passing `PictureSourceType.PHOTOLIBRARY` or `PictureSourceType.SAVEDPHOTOALBUM`
-     * along with `DestinationType.NATIVE_URI` will disable any image modifications (resize, quality
-     * change, cropping, etc.) due to implementation specific.
      *
      * @enum {number}
      */


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`NATIVE_URI` was only used on iOS and windows, on Android it acts like `FILE_URI`.

On iOS it returned `ALAssetsLibrary` urls that are not compatible with `WKWebView` and `ALAssetsLibrary` was deprecated on iOS 9, so I don't think it makes sense to keep this destination type since it's not supported by all platforms and it's deprecated on iOS.


### Description
<!-- Describe your changes in detail -->
also removes other usages of `ALAssetsLibrary` since it's deprecated

### Testing
<!-- Please describe in detail how you tested your changes. -->
tested on real iOS device

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
