### PR TITLE
Update empty filename issue for supporting multiple images

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -335,7 +335,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      */
     private File createCaptureFile(int encodingType, String fileName) {
         if (fileName.isEmpty()) {
-            fileName = ".Pic";
+            //creating timestamps for empty filename to differentiate between multiple files selected via gallery
+            String timeStamp = new SimpleDateFormat(TIME_FORMAT).format(new Date());
+            fileName = timeStamp;
         }
 
         if (encodingType == JPEG) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I was stucked from few days because i am not able to get correct path for the images selected using PHOTOALBUM but then i got a new problem after rectifying the issue i found that the cameraLauncher.java file renaming every image selected from gallery to .Pic. therefore its very difficult to differentiate them and also it is overriding the images.


### Description
<!-- Describe your changes in detail -->

This is required to differ between multiple images as the java file renaming every file to .Pic. so instead this i added timestamp to the empty filename so that the developer can able to differentiate between multiple files and their paths.

### Testing
<!-- Please describe in detail how you tested your changes. -->
I have tested this on android 10 using camera and gallery app in my device and it is working fine.


### Checklist

- [x ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
