### PR TITLE
chore: add release notify action

### DIFF
--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -3,7 +3,6 @@ name: Close issue asking for release
 on:
   issues:
     types: [opened]
-    
 
 jobs:
   action-test:

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -3,8 +3,6 @@ name: Close issue asking for release
 on:
   issues:
     types: [opened]
-  issue_comment:
-    types: [created]
     
 
 jobs:

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -1,0 +1,16 @@
+name: Close issue asking for release
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+    
+
+jobs:
+  action-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: niklasmerz/release-notify@master
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
We want to test a new action that closes issues that are just asking for a new release and reduce noise. Let's start with this plugin.



### Description
<!-- Describe your changes in detail -->
This PR adds a new Github action built by me to add a comment and closes the issue if it looks like the issue is just created to ask for a release.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
