### PR TITLE
Bugfix issue 341 save to photo gallery - Fixes #341, fixes #577

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -73,6 +73,7 @@
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/ExifHelper.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/FileProvider.java" target-dir="src/org/apache/cordova/camera" />
+        <source-file src="src/android/GalleryPathVO.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/xml/camera_provider_paths.xml" target-dir="res/xml" />
 
         <js-module src="www/CameraPopoverHandle.js" name="CameraPopoverHandle">

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -500,7 +500,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             if (this.allowEdit && this.croppedUri != null) {
                 writeUncompressedImage(croppedUri, galleryUri);
             } else {
-                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) { // Between LOLLIPOP_MR1 and P
+                if (Build.VERSION.SDK_INT <= 28) { // Between LOLLIPOP_MR1 and P, can be changed later to the constant Build.VERSION_CODES.P
                     writeTakenPictureToGalleryLowerThanAndroidQ(galleryUri);
                 } else { // Android Q or higher
                     writeTakenPictureToGalleryStartingFromAndroidQ(galleryPathVO);

--- a/src/android/GalleryPathVO.java
+++ b/src/android/GalleryPathVO.java
@@ -1,0 +1,23 @@
+public class GalleryPathVO {
+    private final String galleryPath;
+    private String picturesDirectory;
+    private String galleryFileName;
+
+    public GalleryPathVO(String picturesDirectory, String galleryFileName) {
+        this.picturesDirectory = picturesDirectory;
+        this.galleryFileName = galleryFileName;
+        this.galleryPath = this.picturesDirectory + "/" + this.galleryFileName;
+    }
+
+    public String getGalleryPath() {
+        return galleryPath;
+    }
+
+    public String getPicturesDirectory() {
+        return picturesDirectory;
+    }
+
+    public String getGalleryFileName() {
+        return galleryFileName;
+    }
+}

--- a/src/android/GalleryPathVO.java
+++ b/src/android/GalleryPathVO.java
@@ -1,3 +1,5 @@
+package org.apache.cordova.camera;
+
 public class GalleryPathVO {
     private final String galleryPath;
     private String picturesDirectory;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Fixes #341
- Fixes #577

The saveToPhotoAlbum setting throws an exception while using the camera. (sourceType = CAMERA)
This results in a crash of the application. 
The first bug was reported in september 2018.
This PR only tries to solve the issue for the sourceType Camera.PictureSourceType.CAMERA, not for when the sourceType is PHOTOLIBRARY.
A reproduction of the issue can be done with https://github.com/PieterVanPoyer/cordova-camera-plugin-testing-app repo.

### Description
<!-- Describe your changes in detail -->
- saveToPhotoAlbum feature fixed by taken into count content - uri. (writeUncompressedImage method) ( see: apache#611 (comment) )
- make saveToPhotoAlbum future proof by using the MediaStore to insert the taken image
- made a method to calculate the compressFormat based on the encodingType (JPEG or PNG)
- layout of the performCrop method is adjusted
- removed unused rotate variable inside processResultFromGallery method
- added a GalleryPathVO (ValueObject) for more easy working with the path and imagename.
- add extra VO class to the plugin.xml


### Testing
<!-- Please describe in detail how you tested your changes. -->

I did run npm run test.
Tested on Android emulators from Android 5.1, 7, 10 and 11.
Tested on a real Samsung J7 device (Android 9), tested on a Samsung Galaxy tablet.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
