### PR TITLE
fix(android): Declare CAMERA permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,6 +56,7 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.CAMERA" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/apache/cordova-plugin-camera/issues/471


Fixes permission issue on Android.

Camera permission is generally only required if you're using the Camera APIs, which we don't however there are a few exceptions to this rule.

As of Android M, if you try to request the `CAMERA` permission without declaring it in the manifest, a security error is thrown. See the [Note](https://developer.android.com/reference/android/provider/MediaStore.html#ACTION_IMAGE_CAPTURE) in the android documentation.

The camera plugin does request the `CAMERA` permission to handle an edge case where another plugin may include it in the manifest.

https://github.com/apache/cordova-plugin-camera/blob/5ae56cf8f07bcdfa090d928e7af3c8637521afce/src/android/CameraLauncher.java#L249-L251


### Description
<!-- Describe your changes in detail -->
Adds `<uses-permission android:name="android.permission.CAMERA" />` to `plugin.xml`


### Testing
<!-- Please describe in detail how you tested your changes. -->

- Ran `npm test`.
- Tested on one of my production apps.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
