### PR TITLE
Revert "fix(android): Declare CAMERA permission"

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,6 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.CAMERA" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reverts https://github.com/apache/cordova-plugin-camera/pull/670

The blame is actually not with the plugin, but rather the app. Camera plugin will request camera permissions if the camera permission is declared to support coexisting with other plugins that may need camera permission APIs, but otherwise the plugin does not require the camera permission to be declared and therefore it should not declare itself.

If the app uses a plugin that requires the camera permission, it is up to that plugin to add the camera permission itself.


### Description
<!-- Describe your changes in detail -->
This reverts commit 140e8861e30164da0861fec548d0aa2413197e12.

### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran `npm test`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
