### PR TITLE
fix(android): supports sdk-30 package visibility

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -69,6 +69,17 @@
           </provider>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <queries>
+                <intent>
+                    <action android:name="android.media.action.IMAGE_CAPTURE" />
+                </intent>
+                <intent>
+                    <action android:name="android.intent.action.GET_CONTENT" />
+                </intent>
+            </queries>
+        </config-file>
+
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/ExifHelper.java" target-dir="src/org/apache/cordova/camera" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -77,6 +77,9 @@
                 <intent>
                     <action android:name="android.intent.action.GET_CONTENT" />
                 </intent>
+                <intent>
+                    <action android:name="android.intent.action.PICK" />
+                </intent>
             </queries>
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -80,6 +80,10 @@
                 <intent>
                     <action android:name="android.intent.action.PICK" />
                 </intent>
+                <intent>
+                    <action android:name="com.android.camera.action.CROP" />
+                    <data android:scheme="content" android:mimeType="image/*"/>
+                </intent>
             </queries>
         </config-file>
 


### PR DESCRIPTION
### Platforms affected

android

### Motivation and Context

Fixes issues that were introduced with the new Android 11 (SDK 30) package visibility restrictions.

### Description

Explicitly sets the package visibility for:

* android.media.action.IMAGE_CAPTURE
* android.intent.action.GET_CONTENT
* android.intent.action.PICK

closes #673

Which is used by the camera and gallery.

### Testing

* Tested on an Android 11 SDK 30 AVD

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
