### PR TITLE
fix(android): return exception message (where it exists) 

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -759,7 +759,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
                             } catch (Exception e) {
                                 e.printStackTrace();
-                                this.failPicture("Error retrieving image: "+e.getMessage());
+                                this.failPicture("Error retrieving image: "+e.getLocalizedMessage());
                             }
                         } else {
                             this.callbackContext.success(finalLocation);

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -829,7 +829,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     }
                 } catch (IOException e) {
                     e.printStackTrace();
-                    this.failPicture("Error capturing image: "+e.getMessage());
+                    this.failPicture("Error capturing image: "+e.getLocalizedMessage());
                 }
             }
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1268,7 +1268,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 code = null;
             }
         } catch (Exception e) {
-            this.failPicture("Error compressing image: "+e.getMessage());
+            this.failPicture("Error compressing image: "+e.getLocalizedMessage());
         }
         jpeg_data = null;
     }

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -759,7 +759,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
                             } catch (Exception e) {
                                 e.printStackTrace();
-                                this.failPicture("Error retrieving image.");
+                                this.failPicture("Error retrieving image: "+e.getMessage());
                             }
                         } else {
                             this.callbackContext.success(finalLocation);
@@ -829,7 +829,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     }
                 } catch (IOException e) {
                     e.printStackTrace();
-                    this.failPicture("Error capturing image.");
+                    this.failPicture("Error capturing image: "+e.getMessage());
                 }
             }
 
@@ -1268,7 +1268,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 code = null;
             }
         } catch (Exception e) {
-            this.failPicture("Error compressing image.");
+            this.failPicture("Error compressing image: "+e.getMessage());
         }
         jpeg_data = null;
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I use this plugin in multiple apps and sometimes users encounter errors when using the camera and ask for support.
To help with user support it would be useful to know the cause of the error by returning the exception message (where it exists) in the error message sent to the plugin error callback.
For example, this can be logged to analytics and used to help diagnose the cause of the error.


### Description
<!-- Describe your changes in detail -->
Where an exception is raised and the plugin invokes the error callback, append the exception message to the returned error message.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested on Android device by forcing an exception by appending "FOO" to the `imageUri`, i.e. change [line 615](https://github.com/apache/cordova-plugin-camera/blob/master/src/android/CameraLauncher.java#L615) to:

	InputStream fileStream = org.apache.cordova.camera.FileHelper.getInputStreamFromUriString(imageUri.toString()+"FOO", cordova);

Resulting error callback message: `Error capturing image: open failed: ENOENT (No such file or directory)`	


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [n/a] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [n/a] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [n/a] I've updated the documentation if necessary

