### PR TITLE
Bugfix issue 665

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -92,6 +92,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private static final String GET_All = "Get All";
     private static final String CROPPED_URI_KEY = "croppedUri";
     private static final String IMAGE_URI_KEY = "imageUri";
+    private static final String IMAGE_FILE_PATH_KEY = "imageFilePath";
 
     private static final String TAKE_PICTURE_ACTION = "takePicture";
 
@@ -1350,6 +1351,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             state.putString(IMAGE_URI_KEY, this.imageFilePath);
         }
 
+        if(this.imageFilePath != null) {
+            state.putString(IMAGE_FILE_PATH_KEY, this.imageFilePath);
+        }
+
         return state;
     }
 
@@ -1373,6 +1378,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         if (state.containsKey(IMAGE_URI_KEY)) {
             //I have no idea what type of URI is being passed in
             this.imageUri = Uri.parse(state.getString(IMAGE_URI_KEY));
+        }
+
+        if (state.containsKey(IMAGE_FILE_PATH_KEY)) {
+           this.imageFilePath = state.getString(IMAGE_FILE_PATH_KEY);
         }
 
         this.callbackContext = callbackContext;

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1351,7 +1351,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             state.putString(IMAGE_URI_KEY, this.imageFilePath);
         }
 
-        if(this.imageFilePath != null) {
+        if (this.imageFilePath != null) {
             state.putString(IMAGE_FILE_PATH_KEY, this.imageFilePath);
         }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #665 
Fixes #696 

### Description
<!-- Describe your changes in detail -->

In the processResultFromCamera method, the imageFilePath is used.
https://github.com/apache/cordova-plugin-camera/blob/master/src/android/CameraLauncher.java#L475 
It was not restored when the activity was destroyed.
https://github.com/apache/cordova-plugin-camera/blob/b43c78b41997294d08fc8c17a3b286a5eba5fa6d/src/android/CameraLauncher.java#L1356
This resulted in a NullPointerException because the resulting sourcePath was null.
https://github.com/apache/cordova-plugin-camera/blob/b43c78b41997294d08fc8c17a3b286a5eba5fa6d/src/android/CameraLauncher.java#L473

So I've added the imageFilePath to the state Bundle in the saveInstance and the restoreInstance methods.

You can install and test the plugin (on Android) with next command.

````
npx cordova plugin remove cordova-plugin-camera
npx cordova plugin add https://github.com/PieterVanPoyer/cordova-plugin-camera/#bugfix/issue-665-save-instance-restore-bug
````

You could test it with next reproduction repo:
https://github.com/PieterVanPoyer/cordova-camera-plugin-testing-app

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested it on an Android 10 emulator.
I enabled the developers mode on the emulator and made the activity destroy everytime the camera is shown.
So I forced the resume flow on Android

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
