### PR TITLE
chore: set the 5.x versions locked to cordova-android <10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
         "cordova-ios": ">=5.1.0",
         "cordova": ">=9.0.0"
       },
+      "5.0.3": {
+        "cordova-android": "<10.0.0",
+        "cordova-ios": ">=5.1.0",
+        "cordova": ">=9.0.0"
+      },
       "6.0.0": {
         "cordova": ">100"
       }

--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
 
     <engines>
         <engine name="cordova" version=">=9.0.0"/>
-        <engine name="cordova-android" version=">=9.0.0" />
+        <engine name="cordova-android" version="<10.0.0" />
         <engine name="cordova-ios" version=">=5.1.0" />
     </engines>
 


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

Cordova-Android 10 uses AndroidX... Therefore we should lock this plugin version 5.x to Cordova-Android 9.x

### Description

Lock plugin 5.x to Cordova-Android 9.x

### Testing

- n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
