### PR TITLE
fix(android): update queries in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -69,22 +69,20 @@
           </provider>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <queries>
-                <intent>
-                    <action android:name="android.media.action.IMAGE_CAPTURE" />
-                </intent>
-                <intent>
-                    <action android:name="android.intent.action.GET_CONTENT" />
-                </intent>
-                <intent>
-                    <action android:name="android.intent.action.PICK" />
-                </intent>
-                <intent>
-                    <action android:name="com.android.camera.action.CROP" />
-                    <data android:scheme="content" android:mimeType="image/*"/>
-                </intent>
-            </queries>
+        <config-file target="AndroidManifest.xml" parent="queries">
+            <intent>
+                <action android:name="android.media.action.IMAGE_CAPTURE" />
+            </intent>
+            <intent>
+                <action android:name="android.intent.action.GET_CONTENT" />
+            </intent>
+            <intent>
+                <action android:name="android.intent.action.PICK" />
+            </intent>
+            <intent>
+                <action android:name="com.android.camera.action.CROP" />
+                <data android:scheme="content" android:mimeType="image/*"/>
+            </intent>
         </config-file>
 
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
fixes https://github.com/apache/cordova-plugin-camera/issues/779



### Description
Change the queries element of plugin.xml so that not duplicate elements are created if other plugins or config.xml also contains a queries element



### Testing
Add the following to the projects config.xml and add android platform. Only one queries element should be created in AppManifest.xml.

<config-file parent="queries" target="AndroidManifest.xml">
    <package android:name="<name of package>" />
</config-file>



### Checklist

- [ x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
