### PR TITLE
fix(browser): use navigator.mediaDevices.getUserMedia

### DIFF
--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -113,8 +113,8 @@ function capture (success, errorCallback, opts) {
 
     if (navigator.mediaDevices.getUserMedia) {
         navigator.mediaDevices.getUserMedia({ video: true, audio: false })
-        .then(successCallback)
-        .catch(errorCallback);
+            .then(successCallback)
+            .catch(errorCallback);
     } else if (navigator.getUserMedia) {
         navigator.getUserMedia({ video: true, audio: false }, successCallback, errorCallback);
     } else {

--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -111,7 +111,11 @@ function capture (success, errorCallback, opts) {
         document.body.appendChild(parent);
     };
 
-    if (navigator.getUserMedia) {
+    if (navigator.mediaDevices.getUserMedia) {
+        navigator.mediaDevices.getUserMedia({ video: true, audio: false })
+        .then(successCallback)
+        .catch(errorCallback);
+    } else if (navigator.getUserMedia) {
         navigator.getUserMedia({ video: true, audio: false }, successCallback, errorCallback);
     } else {
         alert('Browser does not support camera :(');


### PR DESCRIPTION
navigator.getUserMedia has been deprecated for a long time, most browsers still support it, but others like safari already removed it and others probably will in the future.

this PR uses navigator.mediaDevices.getUserMedia if available.