### PR TITLE
(ios) workaround for Issue #778

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -406,7 +406,7 @@ static NSString* toBase64(NSData* data) {
                         }
                         [[self locationManager] startUpdatingLocation];
                     }
-                data = nil;
+                    // data = nil; // this causes Issue #778
                 }
             } else if (pickerController.sourceType == UIImagePickerControllerSourceTypePhotoLibrary) {
                 PHAsset* asset = [info objectForKey:@"UIImagePickerControllerPHAsset"];
@@ -659,7 +659,7 @@ static NSString* toBase64(NSData* data) {
         NSString* mediaType = [info objectForKey:UIImagePickerControllerMediaType];
         if ([mediaType isEqualToString:(NSString*)kUTTypeImage]) {
             [weakSelf resultForImage:cameraPicker.pictureOptions info:info completion:^(CDVPluginResult* res) {
-                if (![self usesGeolocation] || picker.sourceType != UIImagePickerControllerSourceTypeCamera) {
+                if (![weakSelf usesGeolocation] || picker.sourceType != UIImagePickerControllerSourceTypeCamera) {
                     [weakSelf.commandDelegate sendPluginResult:res callbackId:cameraPicker.callbackId];
                     weakSelf.hasPendingOperation = NO;
                     weakSelf.pickerController = nil;


### PR DESCRIPTION

### Platforms affected
iOS


### Motivation and Context
Issue #778


### Description
setting data to nil in line 409 crashes the front end app. Therefore I commented it out. This is not a perfect solution for the Issue #778 because we want the location data when `CameraUsesGeolocation`  but better not to crash.



### Testing
with `CameraUsesGeolocation` set to `true` in the config.xml and taking a photo from the Album does not crash anymore on iOS  >= 15


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ +] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [+ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
