### PR TITLE
fix(android): Fixed exif handling when loading picture from gallery

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -783,9 +783,17 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                         try {
                             String modifiedPath = this.outputModifiedBitmap(bitmap, uri, mimeTypeOfGalleryFile);
                             InputStream fileStream = FileHelper.getInputStreamFromUriString(modifiedPath, cordova);
-                            byte[] file = new byte[fileStream.available()];
+                            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
-                            fileStream.read(file);
+                            int nRead;
+                            byte[] data = new byte[512];
+
+                            while ((nRead = fileStream.read(data, 0, data.length)) != -1) {
+                                buffer.write(data, 0, nRead);
+                            }
+
+                            buffer.flush();
+                            byte[] file = buffer.toByteArray();
 
                             byte[] output = Base64.encode(file, Base64.NO_WRAP);
                             String js_out = new String(output);

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -778,7 +778,22 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
                     // If sending base64 image back
                     if (destType == DATA_URL) {
-                        this.processPicture(bitmap, this.encodingType);
+                        // To allow keeping the Exif data, we need to save the image to allow ExifInterface add the data
+                        // After that, we load the image and send it as base64
+                        try {
+                            String modifiedPath = this.outputModifiedBitmap(bitmap, uri, mimeTypeOfGalleryFile);
+                            InputStream fileStream = FileHelper.getInputStreamFromUriString(modifiedPath, cordova);
+                            byte[] file = new byte[fileStream.available()];
+
+                            fileStream.read(file);
+
+                            byte[] output = Base64.encode(file, Base64.NO_WRAP);
+                            String js_out = new String(output);
+                            this.callbackContext.success(js_out);
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                            this.failPicture("Error retrieving image: "+e.getLocalizedMessage());
+                        }
                     }
 
                     // If sending filename back

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -786,7 +786,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                             ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
                             int nRead;
-                            byte[] data = new byte[512];
+                            final int MB = 1048576;
+
+                            byte[] data = new byte[MB * 4];
 
                             while ((nRead = fileStream.read(data, 0, data.length)) != -1) {
                                 buffer.write(data, 0, nRead);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The exif data was removed if we loaded from the gallery in DATA_URL format.

This should fix https://github.com/apache/cordova-plugin-camera/issues/867.

### Description
<!-- Describe your changes in detail -->

Instead for returning the bitmap compressed and encoded in base64, we save it into a file, and apply the input exif data and then we put it back in the memory to encode it in base64 and return it.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I tested my changes in an ionic app that use this feature via `@awesome-cordova-plugins/camera@5.46.0`

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
