### PR TITLE
feat(android): Added `originalDateTime` to exif handling

### DIFF
--- a/src/android/ExifHelper.java
+++ b/src/android/ExifHelper.java
@@ -42,6 +42,7 @@ public class ExifHelper {
     private String model = null;
     private String orientation = null;
     private String whiteBalance = null;
+    private String dateTimeOriginal = null;
 
     private ExifInterface inFile = null;
     private ExifInterface outFile = null;
@@ -89,6 +90,7 @@ public class ExifHelper {
         this.model = inFile.getAttribute(ExifInterface.TAG_MODEL);
         this.orientation = inFile.getAttribute(ExifInterface.TAG_ORIENTATION);
         this.whiteBalance = inFile.getAttribute(ExifInterface.TAG_WHITE_BALANCE);
+        this.dateTimeOriginal = inFile.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL);
     }
 
     /**
@@ -158,6 +160,9 @@ public class ExifHelper {
         }
         if (this.whiteBalance != null) {
             this.outFile.setAttribute(ExifInterface.TAG_WHITE_BALANCE, this.whiteBalance);
+        }
+        if (this.dateTimeOriginal != null) {
+            this.outFile.setAttribute(ExifInterface.TAG_DATETIME_ORIGINAL, this.dateTimeOriginal);
         }
 
         this.outFile.saveAttributes();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

the originalDateTime tag was lost in any operations involving a bitmap. This tag is quite important because it says when a picture has been taken.

### Description
<!-- Describe your changes in detail -->

Added originalDateTime in the exif handling

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested on my ionic app app via `@awesome-cordova-plugins/camera@5.46.0`.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
