### PR TITLE
Fix: Duplicate Permission Error For WRITE_EXTERNAL_STORAGE

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
             <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"" />
             <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
             <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
         </config-file>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix For Duplicate Permission Error For WRITE_EXTERNAL_STORAGE

[https://github.com/apache/cordova-plugin-camera/issues/882](https://github.com/apache/cordova-plugin-camera/issues/882)


### Description
<!-- Describe your changes in detail -->
Due to minSDK check, this was creating multiple permission in Android manifest file.
If you are using any other plugin, which also requires the WRITE_EXTERNAL_STORAGE

Element uses-permission#android.permission.WRITE_EXTERNAL_STORAGE at AndroidManifest.xml:20:5-108 duplicated with element declared at AndroidManifest.xml:13:5-81

### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested with android build process

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
