### PR TITLE
chore: npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org
+


### PR DESCRIPTION
Adds the `.npmrc` file to tell NPM to use the official registry explicitly.

So I don't accidentally push any package-lock changes that references my company's private registry.

progresses https://github.com/apache/cordova/issues/299