### PR TITLE
fix(android): Isolate provider access to a subdirectory

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -367,7 +367,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             throw new IllegalArgumentException("Invalid Encoding Type: " + encodingType);
         }
 
-        return new File(getTempDirectoryPath(), fileName);
+        File cacheDir = new File(getTempDirectoryPath(), "org.apache.cordova.camera");
+        cacheDir.mkdir();
+
+        return new File(cacheDir, fileName);
     }
 
 

--- a/src/android/xml/camera_provider_paths.xml
+++ b/src/android/xml/camera_provider_paths.xml
@@ -17,5 +17,5 @@
 -->
 
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <cache-path name="cache_files" path="." />
+    <cache-path name="cache_files" path="org.apache.cordova.camera/" />
 </paths>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The file provider is what grants app delegates (such as the camera app) access for reading and/or writing. It is what allows the camera intent to write it's image to the app's internal cache directory. The previous configuration allowed access to the entire cache directory which could be perceived as a security risk.

Using a sub-directory will at least isolate access to that specific directory and won't expose other cache files that the app may have stored. The chosen directory is something that should only be used by this plugin, and the directory will be mostly empty assuming that users call the `cleanup` API. Worst case scenario it may have images that was previously captured by the user.

### Description
<!-- Describe your changes in detail -->

Update to provider to path to use a subdirectory, and updated the create code to use subdirectory.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested on using android simulator using `getPicture` API.
Paramedic tests also passes.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
