### PR TITLE
fix(android): always return uris

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -728,77 +728,68 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             }
         }
 
-        String fileLocation = FileHelper.getRealPath(uri, this.cordova);
-        LOG.d(LOG_TAG, "File location is: " + fileLocation);
-
         String uriString = uri.toString();
-        String finalLocation = fileLocation != null ? fileLocation : uriString;
         String mimeTypeOfGalleryFile = FileHelper.getMimeType(uriString, this.cordova);
 
-        if (finalLocation == null) {
-            this.failPicture("Error retrieving result.");
+        // If you ask for video or the selected file cannot be processed
+        // there will be no attempt to resize any returned data.
+        if (this.mediaType == VIDEO  || !isImageMimeTypeProcessable(mimeTypeOfGalleryFile)) {
+            this.callbackContext.success(uriString);
         } else {
-            // If you ask for video or the selected file cannot be processed
-            // there will be no attempt to resize any returned data.
-            if (this.mediaType == VIDEO  || !isImageMimeTypeProcessable(mimeTypeOfGalleryFile)) {
-                this.callbackContext.success(finalLocation);
+
+            // This is a special case to just return the path as no scaling,
+            // rotating, nor compressing needs to be done
+            if (this.targetHeight == -1 && this.targetWidth == -1 &&
+                    destType == FILE_URI && !this.correctOrientation &&
+                    getMimetypeForEncodingType().equalsIgnoreCase(mimeTypeOfGalleryFile))
+            {
+                this.callbackContext.success(uriString);
             } else {
-
-                // This is a special case to just return the path as no scaling,
-                // rotating, nor compressing needs to be done
-                if (this.targetHeight == -1 && this.targetWidth == -1 &&
-                        destType == FILE_URI && !this.correctOrientation &&
-                        getMimetypeForEncodingType().equalsIgnoreCase(mimeTypeOfGalleryFile))
-                {
-                    this.callbackContext.success(finalLocation);
-                } else {
-                    Bitmap bitmap = null;
-                    try {
-                        bitmap = getScaledAndRotatedBitmap(uriString);
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                    if (bitmap == null) {
-                        LOG.d(LOG_TAG, "I either have a null image path or bitmap");
-                        this.failPicture("Unable to create bitmap!");
-                        return;
-                    }
-
-                    // If sending base64 image back
-                    if (destType == DATA_URL) {
-                        this.processPicture(bitmap, this.encodingType);
-                    }
-
-                    // If sending filename back
-                    else if (destType == FILE_URI) {
-                        // Did we modify the image?
-                        if ( (this.targetHeight > 0 && this.targetWidth > 0) ||
-                                (this.correctOrientation && this.orientationCorrected) ||
-                                !mimeTypeOfGalleryFile.equalsIgnoreCase(getMimetypeForEncodingType()))
-                        {
-                            try {
-                                String modifiedPath = this.outputModifiedBitmap(bitmap, uri, mimeTypeOfGalleryFile);
-                                // The modified image is cached by the app in order to get around this and not have to delete you
-                                // application cache I'm adding the current system time to the end of the file url.
-                                this.callbackContext.success("file://" + modifiedPath + "?" + System.currentTimeMillis());
-
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                                this.failPicture("Error retrieving image: "+e.getLocalizedMessage());
-                            }
-                        } else {
-                            this.callbackContext.success(finalLocation);
-                        }
-                    }
-                    if (bitmap != null) {
-                        bitmap.recycle();
-                        bitmap = null;
-                    }
-                    System.gc();
+                Bitmap bitmap = null;
+                try {
+                    bitmap = getScaledAndRotatedBitmap(uriString);
+                } catch (IOException e) {
+                    e.printStackTrace();
                 }
+                if (bitmap == null) {
+                    LOG.d(LOG_TAG, "I either have a null image path or bitmap");
+                    this.failPicture("Unable to create bitmap!");
+                    return;
+                }
+
+                // If sending base64 image back
+                if (destType == DATA_URL) {
+                    this.processPicture(bitmap, this.encodingType);
+                }
+
+                // If sending filename back
+                else if (destType == FILE_URI) {
+                    // Did we modify the image?
+                    if ( (this.targetHeight > 0 && this.targetWidth > 0) ||
+                            (this.correctOrientation && this.orientationCorrected) ||
+                            !mimeTypeOfGalleryFile.equalsIgnoreCase(getMimetypeForEncodingType()))
+                    {
+                        try {
+                            String modifiedPath = this.outputModifiedBitmap(bitmap, uri, mimeTypeOfGalleryFile);
+                            // The modified image is cached by the app in order to get around this and not have to delete you
+                            // application cache I'm adding the current system time to the end of the file url.
+                            this.callbackContext.success("file://" + modifiedPath + "?" + System.currentTimeMillis());
+
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                            this.failPicture("Error retrieving image: "+e.getLocalizedMessage());
+                        }
+                    } else {
+                        this.callbackContext.success(uriString);
+                    }
+                }
+                if (bitmap != null) {
+                    bitmap.recycle();
+                    bitmap = null;
+                }
+                System.gc();
             }
         }
-
     }
 
     /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

This PR contains https://github.com/apache/cordova-plugin-camera/pull/901, will rebase after it's merged.

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/apache/cordova-plugin-camera/issues/875
closes https://github.com/apache/cordova-plugin-camera/issues/783
closes https://github.com/apache/cordova-plugin-camera/issues/761
closes https://github.com/apache/cordova-plugin-camera/issues/422
closes https://github.com/apache/cordova-plugin-camera/issues/746
closes https://github.com/apache/cordova-plugin-camera/issues/347

The `finalLocation` returns raw file paths, which isn't always usable especially with Scoped Access Framework. Instead return the stringified URI, which has temporary permission granted.

With file plugin 8.1.1 `content://` paths are resolvable.

**NOTE**: I've since realised that `DATA_URL` also doesn't properly return the data url (it is missing the scheme prefix). I however will consider that out of scope and correct that in another PR.

### Description
<!-- Describe your changes in detail -->

Removed finding the raw file path, which was not used other than to return it.

All `finalLocation` usage, which was used to return back to the webview now returns `uriString` instead. This usually a `file://` or a `content://` uri.

Simplified logic and removed conditions surrounding handling `finalLocation`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual testing images picked from gallery of different formats.
Paramedic tests passes.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
