### PR TITLE
fix(android): Improper serialization of image uri in save instance state

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1375,7 +1375,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
 
         if (this.imageUri != null) {
-            state.putString(IMAGE_URI_KEY, this.imageFilePath);
+            state.putString(IMAGE_URI_KEY, this.imageUri.toString());
         }
 
         if (this.imageFilePath != null) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The imageUri field is not properly restored if the activity is killed,
which can cause further issues.

This is because `imageFilePath` was used instead for the imageUri which only contains the
path of the original URI, losing the scheme in the process.

### Description
<!-- Describe your changes in detail -->

Serialize using `imageUri.toString()` instead of using the imageFilePath

### Testing
<!-- Please describe in detail how you tested your changes. -->

paramedic testing + testing with `Don't Keep Activities` developer option enabled.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
