### PR TITLE
refactor(android): remove query img usage

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -615,7 +615,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 throw new IllegalStateException();
             }
 
-            this.cleanup(FILE_URI, this.imageUri, galleryUri, bitmap);
+            this.cleanup(this.imageUri, galleryUri, bitmap);
             bitmap = null;
             input.close();
         }
@@ -1199,9 +1199,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     /**
      * Cleans up after picture taking. Checking for duplicates and that kind of stuff.
      *
-     * @param newImage - No longer used
+     * @param newImage
      */
-    private void cleanup(int imageType, Uri oldImage, Uri newImage, Bitmap bitmap) {
+    private void cleanup(Uri oldImage, Uri newImage, Bitmap bitmap) {
         if (bitmap != null) {
             bitmap.recycle();
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

Will rebase after https://github.com/apache/cordova-plugin-camera/pull/906 & https://github.com/apache/cordova-plugin-camera/pull/902 is merged.

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

fixes https://github.com/apache/cordova-plugin-camera/issues/891
closes https://github.com/apache/cordova-plugin-camera/issues/725
closes https://github.com/apache/cordova-plugin-camera/issues/660

This code existed since the beginning of time and it does not appear to be relevant anymore.
Duplicates does not occur, even with using DATA_URL or creating modifications via scaling.

Additionally querying the media store on API 28 and lower requires broad `READ_EXTERNAL_STORAGE` permission. If we can remove `numpics` and the usage of `queryImgDb` then we can make `READ/WRITE_EXTERNAL_STORAGE` optional.

With this change, on API 29+ no permissions are necessary to use the plugin, except for `CAMERA` if it's declared (that workaround is still necessary).

On API 28 and lower, `WRITE_EXTERNAL_PERMISSION` is optional, but will be required if `saveToPhotoAlbum` option is enabled, which is a change I plan to make in another PR soon.

Additionally, the way it was detecting and attempting to remove duplicate images is dangerous, as media store objects can be inserted at any time by other applications. There is no guarantee that the image selected as the duplicate was actually the duplicate, or if there was a duplicate to begin with.

### Description
<!-- Describe your changes in detail -->

Removed `numpics` and all code related to managing `numpics`

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual test on API 24
Paramedic test passes

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
