### PR TITLE
refactor(android): Make WRITE_EXTERNAL_STORAGE optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ quality, even if a `quality` parameter is specified.  To avoid common
 memory problems, set `Camera.destinationType` to `FILE_URI` rather
 than `DATA_URL`.
 
+__NOTE__: To use `saveToPhotoAlbum` option on Android 9 (API 28) and lower, the `WRITE_EXTERNAL_STORAGE` permission must be declared.
+
+To do this, add the following in your `config.xml`:
+
+```xml
+<config-file target="AndroidManifest.xml" parent="/*" xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+</config-file>
+```
+
+Android 10 (API 29) and later devices does not require `WRITE_EXTERNAL_STORAGE` permission. If your application only supports Android 10 or later, then this step is not necessary.
+
 #### FILE_URI Usage
 
 When `FILE_URI` is used, the returned path is not directly usable. The file path needs to be resolved into
@@ -301,7 +313,7 @@ Optional parameters to customize the camera settings.
 | targetHeight | <code>number</code> |  | Height in pixels to scale image. Must be used with `targetWidth`. Aspect ratio remains constant. |
 | mediaType | <code>[MediaType](#module_Camera.MediaType)</code> | <code>PICTURE</code> | Set the type of media to select from.  Only works when `PictureSourceType` is `PHOTOLIBRARY` or `SAVEDPHOTOALBUM`. |
 | correctOrientation | <code>Boolean</code> |  | Rotate the image to correct for the orientation of the device during capture. |
-| saveToPhotoAlbum | <code>Boolean</code> |  | Save the image to the photo album on the device after capture. |
+| saveToPhotoAlbum | <code>Boolean</code> |  | Save the image to the photo album on the device after capture.<br />See [Android Quirks](#cameragetpicturesuccesscallback-errorcallback-options). |
 | popoverOptions | <code>[CameraPopoverOptions](#module_CameraPopoverOptions)</code> |  | iOS-only options that specify popover location in iPad. |
 | cameraDirection | <code>[Direction](#module_Camera.Direction)</code> | <code>BACK</code> | Choose the camera to use (front- or back-facing). |
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -217,22 +217,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     // LOCAL METHODS
     //--------------------------------------------------------------------------
 
-    private String[] getPermissions(boolean storageOnly, int mediaType) {
-        ArrayList<String> permissions = new ArrayList<>();
-
-        if (android.os.Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
-            // Android API 30 or lower
-            permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
-            permissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        }
-        if (!storageOnly) {
-            // Add camera permission when not storage.
-            permissions.add(Manifest.permission.CAMERA);
-        }
-
-        return permissions.toArray(new String[0]);
-    }
-
     private String getTempDirectoryPath() {
         File cache = cordova.getActivity().getCacheDir();
         // Create the cache directory if it doesn't exist

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1360,15 +1360,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         this.callbackContext = callbackContext;
     }
 
-    private boolean hasPermissions(String[] permissions) {
-        for (String permission: permissions) {
-            if (!PermissionHelper.hasPermission(this, permission)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /**
      * Gets the ideal buffer size for processing streams of data.
      *

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -196,6 +196,13 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     this.getImage(this.srcType, destType);
                 }
             }
+            catch (IllegalStateException e)
+            {
+                callbackContext.error(e.getLocalizedMessage());
+                PluginResult r = new PluginResult(PluginResult.Status.ERROR);
+                callbackContext.sendPluginResult(r);
+                return true;
+            }
             catch (IllegalArgumentException e)
             {
                 callbackContext.error("Illegal Argument Exception");
@@ -238,7 +245,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      * @param encodingType           Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
      */
-    public void callTakePicture(int returnType, int encodingType) {
+    public void callTakePicture(int returnType, int encodingType) throws IllegalStateException {
 
         // CB-10120: The CAMERA permission does not need to be requested unless it is declared
         // in AndroidManifest.xml. This plugin does not declare it, but others may and so we must
@@ -282,6 +289,12 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
 
         if (saveToPhotoAlbum && !writeExternalPermissionGranted) {
+            // This block only applies for API 24-28
+            // because writeExternalPermissionGranted is always true on API 29+
+            if (!manifestContainsWriteExternalPermission) {
+                throw new IllegalStateException("WRITE_EXTERNAL_STORAGE permission not declared in AndroidManifest");
+            }
+
             requiredPermissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Depends on https://github.com/apache/cordova-plugin-camera/pull/907

closes https://github.com/apache/cordova-plugin-camera/issues/861
closes https://github.com/apache/cordova-plugin-camera/issues/876

Across all API levels that we support, no permissions are necessary for reading from
gallery. This is because we use the Media Store and gain temporary access to the content.

Across all API levels that we support, no permissions are necessary for capturing an image from the camera. This is because we use an internal app cache directory and we grant the camera app to use this path.

Where permissions might be necessary is with the `saveToPhotoAlbum` option. If enabled, non scoped access devices (API 24-28) do require `WRITE_EXTERNAL_STORAGE` to write to the device's gallery. API 29+ with scoped access framework, no permissions are required.

This PR allows to be more modern on modern devices, and allows the user to opt into `WRITE_EXTERNAL_STORAGE` by providing the necessary `config.xml` directives, if they plan on using `saveToPhotoAlbum` option.

Users that don't want to save to the photo album does not need to declare any extra permissions.

### Description
<!-- Describe your changes in detail -->

Reworked permission management so that `WRITE_EXTERNAL_STORAGE` is optional. `READ_EXTERNAL_STORAGE` is completely obsolete and has been removed.

The `CAMERA` permission workaround is still relevant across all API levels. If declared, the permission must be granted to use the camera intent and that workaround still remains.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual testing on API 28 & 34.
Paramedic test passes

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
