### PR TITLE
fix(android): Return data uris as an URI

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1286,23 +1286,25 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param bitmap
      */
     public void processPicture(Bitmap bitmap, int encodingType) {
-        ByteArrayOutputStream jpeg_data = new ByteArrayOutputStream();
+        ByteArrayOutputStream dataStream = new ByteArrayOutputStream();
         CompressFormat compressFormat = getCompressFormatForEncodingType(encodingType);
 
         try {
-            if (bitmap.compress(compressFormat, mQuality, jpeg_data)) {
-                byte[] code = jpeg_data.toByteArray();
+            if (bitmap.compress(compressFormat, mQuality, dataStream)) {
+                StringBuilder sb = new StringBuilder()
+                    .append("data:")
+                    .append(encodingType == PNG ? PNG_MIME_TYPE : JPEG_MIME_TYPE)
+                    .append(";base64,");
+                byte[] code = dataStream.toByteArray();
                 byte[] output = Base64.encode(code, Base64.NO_WRAP);
-                String js_out = new String(output);
-                this.callbackContext.success(js_out);
-                js_out = null;
+                sb.append(new String(output));
+                this.callbackContext.success(sb.toString());
                 output = null;
                 code = null;
             }
         } catch (Exception e) {
             this.failPicture("Error compressing image: "+e.getLocalizedMessage());
         }
-        jpeg_data = null;
     }
 
     /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Makes data urls returned as actual URIs instead of just the base 64 encoded data.
This sisters PR https://github.com/apache/cordova-plugin-camera/pull/902

Closes https://github.com/apache/cordova-plugin-camera/issues/420

### Description
<!-- Describe your changes in detail -->

Prefixes the base64 with the data uri header.

### Testing
<!-- Please describe in detail how you tested your changes. -->

paramedic tests passes
Manual testing

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
