### PR TITLE
fix(browser): Make data uri be returned as actual URI strings

### DIFF
--- a/src/browser/CameraProxy.js
+++ b/src/browser/CameraProxy.js
@@ -39,7 +39,7 @@ function takePicture (success, error, opts) {
 
                 const imageData = readerEvent.target.result;
 
-                return success(imageData.substr(imageData.indexOf(',') + 1));
+                return success(imageData);
             };
 
             reader.readAsDataURL(inputEvent.target.files[0]);
@@ -78,8 +78,7 @@ function capture (success, errorCallback, opts) {
         canvas.getContext('2d').drawImage(video, 0, 0, targetWidth, targetHeight);
 
         // convert image stored in canvas to base64 encoded image
-        let imageData = canvas.toDataURL('image/png');
-        imageData = imageData.replace('data:image/png;base64,', '');
+        const imageData = canvas.toDataURL('image/png');
 
         // stop video stream, remove video and button.
         // Note that MediaStream.stop() is deprecated as of Chrome 47.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Browser

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Make the browser platform API consistent with v8 API changes of other platforms.

### Description
<!-- Describe your changes in detail -->

Removed data uri header stripping so that the returned string is the full DOM-usable Data uri string.

Unlike other platforms, browsers only supports DATA_URLs.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual testing

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
