### PR TITLE
deprecation: allowEdit

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Optional parameters to customize the camera settings.
 | quality | <code>number</code> | <code>50</code> | Quality of the saved image, expressed as a range of 0-100, where 100 is typically full resolution with no loss from file compression. (Note that information about the camera's resolution is unavailable.) |
 | destinationType | <code>[DestinationType](#module_Camera.DestinationType)</code> | <code>FILE_URI</code> | Choose the format of the return value. |
 | sourceType | <code>[PictureSourceType](#module_Camera.PictureSourceType)</code> | <code>CAMERA</code> | Set the source of the picture. |
-| allowEdit | <code>Boolean</code> | <code>false</code> | Allow simple editing of image before selection. |
+| ~~allowEdit~~ | <code>Boolean</code> | <code>false</code> | **Deprecated**. Allow simple editing of image before selection. |
 | encodingType | <code>[EncodingType](#module_Camera.EncodingType)</code> | <code>JPEG</code> | Choose the  returned image file's encoding. |
 | targetWidth | <code>number</code> |  | Width in pixels to scale image. Must be used with `targetHeight`. Aspect ratio remains constant. |
 | targetHeight | <code>number</code> |  | Height in pixels to scale image. Must be used with `targetWidth`. Aspect ratio remains constant. |

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -143,6 +143,10 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     const popoverOptions = getValue(options.popoverOptions, null);
     const cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
 
+    if (allowEdit) {
+        console.warn('allowEdit is deprecated. It does not work reliably on all platforms. Utilise a dedicated image editing library instead. allowEdit functionality is scheduled to be removed in the next major release.');
+    }
+
     const args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
         mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
 

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -144,7 +144,7 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     const cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
 
     if (allowEdit) {
-        console.warn('allowEdit is deprecated. It does not work reliably on all platforms. Utilise a dedicated image editing library instead. allowEdit functionality is scheduled to be removed in the next major release.');
+        console.warn('allowEdit is deprecated. It does not work reliably on all platforms. Utilise a dedicated image editing library instead. allowEdit functionality is scheduled to be removed in a future release.');
     }
 
     const args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Deprecate allowEdit. It's already known and documented that on Android that it's unreliable and unsafe to use for reasons outside of our control. While it might be stable enough for iOS, I don't think we can ever provide the same capability for Android without grossly entering scope creep for the plugin responsibilities.

Generally speaking we should refrain from having platform-specific features. Therefore I propose to formally deprecate it in v8.0.0 so that we can indicate that we don't intend to support issues arising form using `allowEdit`, either on iOS or on android.

Note: While I have language indicating that it will be removed v9.0.0, that will obviously depend on who decides to make that release in the future, so don't consider have to consider it as a promise, but it should serve as a sufficient warning that in v9 or any future release the feature can disappear.

### Description
<!-- Describe your changes in detail -->

Adds a deprecation warning in the JS console, if `getPicture` is used with `allowEdit === true`

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm test`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
