### PR TITLE
fix(android): remove WRITE_EXTERNAL_PERMISSION

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -54,9 +54,6 @@
                 <param name="android-package" value="org.apache.cordova.camera.CameraLauncher"/>
             </feature>
         </config-file>
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="30" />
-        </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider
               android:name="org.apache.cordova.camera.FileProvider"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This was intended to be part of https://github.com/apache/cordova-plugin-camera/pull/909
But I forgot to sync the change to `plugin.xml`

### Description
<!-- Describe your changes in detail -->

Removes the automatic declaration for `WRITE_EXTERNAL_STORAGE`, letting end users add it to their config.xml if they need it depending on their use cases.

### Testing
<!-- Please describe in detail how you tested your changes. -->

YOLO paramedic (j.k. I've done lots of testing with and without the declaration)

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
