### PR TITLE
chore: remove trailing whitespace from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ __Supported Platforms__
 
 More examples [here](#camera-getPicture-examples). Quirks [here](#camera-getPicture-quirks).
 
-**Kind**: static method of <code>[camera](#module_camera)</code>  
+**Kind**: static method of <code>[camera](#module_camera)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -226,7 +226,7 @@ More examples [here](#camera-getPicture-examples). Quirks [here](#camera-getPict
 | errorCallback | <code>[onError](#module_camera.onError)</code> |  |
 | options | <code>[CameraOptions](#module_camera.CameraOptions)</code> | CameraOptions |
 
-**Example**  
+**Example**
 ```js
 navigator.camera.getPicture(cameraSuccess, cameraError, cameraOptions);
 ```
@@ -242,8 +242,8 @@ __Supported Platforms__
 
 - iOS
 
-**Kind**: static method of <code>[camera](#module_camera)</code>  
-**Example**  
+**Kind**: static method of <code>[camera](#module_camera)</code>
+**Example**
 ```js
 navigator.camera.cleanup(onSuccess, onFail);
 
@@ -260,7 +260,7 @@ function onFail(message) {
 ### camera.onError : <code>function</code>
 Callback function that provides an error message.
 
-**Kind**: static typedef of <code>[camera](#module_camera)</code>  
+**Kind**: static typedef of <code>[camera](#module_camera)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -271,13 +271,13 @@ Callback function that provides an error message.
 ### camera.onSuccess : <code>function</code>
 Callback function that provides the image data.
 
-**Kind**: static typedef of <code>[camera](#module_camera)</code>  
+**Kind**: static typedef of <code>[camera](#module_camera)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
 | imageData | <code>string</code> | Data URI, _or_ the image file URI, depending on [`cameraOptions`](#module_camera.CameraOptions) in effect. |
 
-**Example**  
+**Example**
 ```js
 // Show image captured with FILE_URI
 function cameraCallback(imageData) {
@@ -299,7 +299,7 @@ function cameraCallback(imageData) {
 Optional parameters to customize the camera settings.
 * [Quirks](#CameraOptions-quirks)
 
-**Kind**: static typedef of <code>[camera](#module_camera)</code>  
+**Kind**: static typedef of <code>[camera](#module_camera)</code>
 **Properties**
 
 | Name | Type | Default | Description |
@@ -327,7 +327,7 @@ Optional parameters to customize the camera settings.
 ### Camera.DestinationType : <code>enum</code>
 Defines the output format of `Camera.getPicture` call.
 
-**Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
+**Kind**: static enum property of <code>[Camera](#module_Camera)</code>
 **Properties**
 
 | Name | Type | Default | Description |
@@ -338,7 +338,7 @@ Defines the output format of `Camera.getPicture` call.
 <a name="module_Camera.EncodingType"></a>
 
 ### Camera.EncodingType : <code>enum</code>
-**Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
+**Kind**: static enum property of <code>[Camera](#module_Camera)</code>
 **Properties**
 
 | Name | Type | Default | Description |
@@ -349,7 +349,7 @@ Defines the output format of `Camera.getPicture` call.
 <a name="module_Camera.MediaType"></a>
 
 ### Camera.MediaType : <code>enum</code>
-**Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
+**Kind**: static enum property of <code>[Camera](#module_Camera)</code>
 **Properties**
 
 | Name | Type | Default | Description |
@@ -363,7 +363,7 @@ Defines the output format of `Camera.getPicture` call.
 ### Camera.PictureSourceType : <code>enum</code>
 Defines the output format of `Camera.getPicture` call.
 
-**Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
+**Kind**: static enum property of <code>[Camera](#module_Camera)</code>
 **Properties**
 
 | Name | Type | Default | Description |
@@ -377,21 +377,21 @@ Defines the output format of `Camera.getPicture` call.
 ### Camera.PopoverArrowDirection : <code>enum</code>
 Matches iOS UIPopoverArrowDirection constants to specify arrow location on popover.
 
-**Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
+**Kind**: static enum property of <code>[Camera](#module_Camera)</code>
 **Properties**
 
 | Name | Type | Default |
 | --- | --- | --- |
-| ARROW_UP | <code>number</code> | <code>1</code> | 
-| ARROW_DOWN | <code>number</code> | <code>2</code> | 
-| ARROW_LEFT | <code>number</code> | <code>4</code> | 
-| ARROW_RIGHT | <code>number</code> | <code>8</code> | 
-| ARROW_ANY | <code>number</code> | <code>15</code> | 
+| ARROW_UP | <code>number</code> | <code>1</code> |
+| ARROW_DOWN | <code>number</code> | <code>2</code> |
+| ARROW_LEFT | <code>number</code> | <code>4</code> |
+| ARROW_RIGHT | <code>number</code> | <code>8</code> |
+| ARROW_ANY | <code>number</code> | <code>15</code> |
 
 <a name="module_Camera.Direction"></a>
 
 ### Camera.Direction : <code>enum</code>
-**Kind**: static enum property of <code>[Camera](#module_Camera)</code>  
+**Kind**: static enum property of <code>[Camera](#module_Camera)</code>
 **Properties**
 
 | Name | Type | Default | Description |
@@ -434,7 +434,7 @@ __Supported Platforms__
 
 - iOS
 
-**Example**  
+**Example**
 ```js
 navigator.camera.getPicture(onSuccess, onFail,
 {
@@ -708,11 +708,11 @@ function getFileEntry(imgUri) {
         window.resolveLocalFileSystemURL(cordova.file.dataDirectory, function (dataDirectoryEntry) {
             fileEntry.copyTo(dataDirectoryEntry, "profilePic", onSuccess, onError);
         }, onError);
-        
+
         // Example 2: Upload it!
         fileEntry.file(function (file) {
             var reader = new FileReader();
-            
+
             reader.onloadend = function() {
                 var xhr = new XMLHttpRequest();
                 xhr.open('POST', 'https://myserver.com/upload');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Formatting cleanup of README for doc generation

### Description
<!-- Describe your changes in detail -->

- Removed trailing whitespace

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
