### PR TITLE
fix(android): Prevent out of memory errors on Android when selecting large media (video) files from the gallery picker.

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -741,6 +741,23 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         String uriString = uri.toString();
         String mimeTypeOfGalleryFile = FileHelper.getMimeType(uriString, this.cordova);
+
+        // If you ask for video or the selected file cannot be processed
+        // there will be no attempt to resize any returned data.
+        if (this.mediaType == VIDEO || !isImageMimeTypeProcessable(mimeTypeOfGalleryFile)) {
+            this.callbackContext.success(uriString);
+            return;
+        }
+
+        // This is a special case to just return the path as no scaling,
+        // rotating, nor compressing needs to be done
+        if (this.targetHeight == -1 && this.targetWidth == -1 &&
+                destType == FILE_URI && !this.correctOrientation &&
+                getMimetypeForEncodingType().equalsIgnoreCase(mimeTypeOfGalleryFile)) {
+            this.callbackContext.success(uriString);
+            return;
+        }
+
         InputStream input;
         try {
             input = cordova.getActivity().getContentResolver().openInputStream(uri);
@@ -756,105 +773,53 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         try {
             byte[] data = readData(input);
+            Bitmap bitmap = null;
 
-            // If you ask for video or the selected file cannot be processed
-            // there will be no attempt to resize any returned data.
-            if (this.mediaType == VIDEO || !isImageMimeTypeProcessable(mimeTypeOfGalleryFile)) {
-                this.callbackContext.success(uriString);
-            } else {
-                Bitmap bitmap = null;
-
-                // This is a special case to just return the path as no scaling,
-                // rotating, nor compressing needs to be done
-                if (this.targetHeight == -1 && this.targetWidth == -1 &&
-                    destType == FILE_URI && !this.correctOrientation &&
-                    getMimetypeForEncodingType().equalsIgnoreCase(mimeTypeOfGalleryFile)) {
-                    this.callbackContext.success(uriString);
-                } else {
-                    try {
-                        bitmap = getScaledAndRotatedBitmap(data, mimeTypeOfGalleryFile);
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                    if (bitmap == null) {
-                        LOG.d(LOG_TAG, "I either have an unreadable uri or null bitmap");
-                        this.failPicture("Unable to create bitmap!");
-                        return;
-                    }
-
-                    // If sending base64 image back
-                    if (destType == DATA_URL) {
-                        this.processPicture(bitmap, this.encodingType);
-                    }
-
-                    // If sending filename back
-                    else if (destType == FILE_URI) {
-                        // Did we modify the image?
-                        if ((this.targetHeight > 0 && this.targetWidth > 0) ||
-                            (this.correctOrientation && this.orientationCorrected) ||
-                            !mimeTypeOfGalleryFile.equalsIgnoreCase(getMimetypeForEncodingType())) {
-                            try {
-                                String modifiedPath = this.outputModifiedBitmap(bitmap, uri, mimeTypeOfGalleryFile);
-                                // The modified image is cached by the app in order to get around this and not have to delete you
-                                // application cache I'm adding the current system time to the end of the file url.
-                                this.callbackContext.success("file://" + modifiedPath + "?" + System.currentTimeMillis());
-
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                                this.failPicture("Error retrieving image: " + e.getLocalizedMessage());
-                            }
-                        } else {
-                            this.callbackContext.success(uriString);
-                        }
-                    }
-                    if (bitmap != null) {
-                        bitmap.recycle();
-                        bitmap = null;
-                    }
-                    System.gc();
-                }
-                if (bitmap == null) {
-                    LOG.d(LOG_TAG, "I either have an unreadable uri or null bitmap");
-                    this.failPicture("Unable to create bitmap!");
-                    return;
-                }
-
-                // If sending base64 image back
-                if (destType == DATA_URL) {
-                    this.processPicture(bitmap, this.encodingType);
-                }
-
-                // If sending filename back
-                else if (destType == FILE_URI) {
-                    // Did we modify the image?
-                    if ( (this.targetHeight > 0 && this.targetWidth > 0) ||
-                            (this.correctOrientation && this.orientationCorrected) ||
-                            !mimeTypeOfGalleryFile.equalsIgnoreCase(getMimetypeForEncodingType()))
-                    {
-                        try {
-                            String modifiedPath = this.outputModifiedBitmap(bitmap, uri, mimeTypeOfGalleryFile);
-                            // The modified image is cached by the app in order to get around this and not have to delete you
-                            // application cache I'm adding the current system time to the end of the file url.
-                            this.callbackContext.success("file://" + modifiedPath + "?" + System.currentTimeMillis());
-
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                            this.failPicture("Error retrieving image: "+e.getLocalizedMessage());
-                        }
-                    } else {
-                        this.callbackContext.success(uriString);
-                    }
-                }
-                if (bitmap != null) {
-                    bitmap.recycle();
-                    bitmap = null;
-                }
-                System.gc();
+            try {
+                bitmap = getScaledAndRotatedBitmap(data, mimeTypeOfGalleryFile);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
 
+            if (bitmap == null) {
+                LOG.d(LOG_TAG, "I either have an unreadable uri or null bitmap");
+                this.failPicture("Unable to create bitmap!");
+                return;
+            }
+
+            // If sending base64 image back
+            if (destType == DATA_URL) {
+                this.processPicture(bitmap, this.encodingType);
+            }
+            // If sending filename back
+            else if (destType == FILE_URI) {
+                // Did we modify the image?
+                if ((this.targetHeight > 0 && this.targetWidth > 0) ||
+                        (this.correctOrientation && this.orientationCorrected) ||
+                        !mimeTypeOfGalleryFile.equalsIgnoreCase(getMimetypeForEncodingType())) {
+                    try {
+                        String modifiedPath = this.outputModifiedBitmap(bitmap, uri, mimeTypeOfGalleryFile);
+                        // The modified image is cached by the app in order to get around this and not have to delete you
+                        // application cache I'm adding the current system time to the end of the file url.
+                        this.callbackContext.success("file://" + modifiedPath + "?" + System.currentTimeMillis());
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        this.failPicture("Error retrieving image: " + e.getLocalizedMessage());
+                    }
+                } else {
+                    this.callbackContext.success(uriString);
+                }
+            }
+
+            if (bitmap != null) {
+                bitmap.recycle();
+                bitmap = null;
+            }
+
+            System.gc();
             input.close();
-        }
-        catch (Exception e) {
+        }  catch (Exception e) {
             try {
                 input.close();
             } catch (IOException ex) {


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
Changes from #906 resulted in all gallery picker results being read in full into a byte array. 
See [this line](https://github.com/apache/cordova-plugin-camera/pull/906/files#diff-96b84e501d011b0ecc5db8468a5ec6a08b919be8bcc731eaf5df174ea6cbf574R767).

Reading in the data fully into memory works generally fine when dealing with images.
When handling larger files (videos for example), it will nearly always result in an out of memory error (reading too much data in one go). 
With videos no transformation is required, the URI simply need to be returned.

Steps to recreate issue:
* On Android, trigger `camera.getPicture` with
   * `destinationType` as `Camera.DestinationType.FILE_URI`
   * `mediaType` as `Camera.MediaType .VIDEO`
   * `sourceType` as `Camera.PictureSourceType.PHOTOLIBRARY`
* Select a large video (typically > 200mb will do it for most devices)
* App will crash due to an Out of Memory exception
   * Similar to 
   > AndroidRuntime: java.lang.OutOfMemoryError: Failed to allocate a 268435472 byte allocation with 100663296 free bytes and 123MB until OOM, target footprint 239130480, growth limit 268435456


### Description

Re-ordered and cleaned up the code for `processResultFromGallery` to only read the file data when required.
If its a video or MIME type which it cannot transform, then simply return the URI.
Similarly if the special case for just returning the path without scaling is met, avoid reading in any data.

### Testing
* Tested image selection from gallery on Pixel 6a (Android 14 & Android 15) and Samsung S10 (Android 12) devices. 
   * Range of different sized (MB) images.
* Tested video selection from gallery on Pixel 6a (Android 14 & Android 15) and Samsung S10 (Android 12) devices. 
   * Range of different sized (MB) videos (10MB - 1GB).

No issues spotted. Images and videos were selected and saved into application storage without issue.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
