### PR TITLE
fix(android): Error propagation when no Camera application is available

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -332,6 +332,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             else
             {
                 LOG.d(LOG_TAG, "Error: You don't have a default camera.  Your device may not be CTS complaint.");
+                throw new IllegalStateException("No camera application available.");
             }
         }
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

fixes https://github.com/apache/cordova-plugin-camera/issues/925

### Description
<!-- Describe your changes in detail -->

Raise an error which is caught and propagated to the JS via the error callback as a string, matching the [documented](https://github.com/apache/cordova-plugin-camera?tab=readme-ov-file#cameraonerror--function) error signature.

![image](https://github.com/user-attachments/assets/24f2f403-6a2a-47ae-b520-52daaa2207e0)


### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual testing. Easiest to test by disabling the default camera application on a simulator.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
