### PR TITLE
refactor(ios): `resultForImage:`

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -765,29 +765,29 @@ static NSString* MIME_JPEG    = @"image/jpeg";
             if (imageData) {
                 if (pictureOptions.sourceType == UIImagePickerControllerSourceTypePhotoLibrary) {
                     
-                    // Copy custom choosen meta data stored in self.metadata to the image
-                    // This will make the image smaller
-                    NSMutableData *imageDataWithExif = nil;
+                    NSData *imageDataToWrite = imageData;
                     
+                    // Copy custom choosen meta data stored in self.metadata to the image
                     if (self.metadata) {
-                        imageDataWithExif = [NSMutableData data];
+                        NSMutableData *imageDataWithCustomMetaData = [NSMutableData data];
                         
                         // Prepare source image
-                        CGImageSourceRef sourceImage = CGImageSourceCreateWithData((__bridge CFDataRef)self.data, NULL);
+                        CGImageSourceRef sourceImage = CGImageSourceCreateWithData((__bridge CFDataRef)imageDataToWrite, NULL);
                         CFStringRef sourceType = CGImageSourceGetType(sourceImage);
                         
                         // Prepare dest image
-                        CGImageDestinationRef destinationImage = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageDataWithExif, sourceType, 1, NULL);
+                        CGImageDestinationRef destinationImage = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageDataWithCustomMetaData, sourceType, 1, NULL);
                         
-                        // Copy source to dest with metadata
+                        // Copy source to dest with self.metadata
                         CGImageDestinationAddImageFromSource(destinationImage, sourceImage, 0, (__bridge CFDictionaryRef)self.metadata);
                         CGImageDestinationFinalize(destinationImage);
 
                         CFRelease(sourceImage);
                         CFRelease(destinationImage);
+                        
+                        imageDataToWrite = imageDataWithCustomMetaData;
                     }
 
-                    NSData *imageDataToWrite = imageDataWithExif != nil ? imageDataWithExif : imageData;
                     NSString* tempFilePath = [self tempFilePathForExtension:pictureOptions.encodingType == EncodingTypePNG ? @"png":@"jpg"];
                     NSError* err = nil;
                     


### PR DESCRIPTION
- Document meta data processing
- Remove any reference of `self.cdvUIImagePickerController` since it is not needed here and also not set, when `PHPickerViewController` is used
- Use `pictureOptions.sourceType` instead of `self.cdvUIImagePickerController.sourceType`
- Use `pictureOptions` parameter instead of `self.cdvUIImagePickerController.pictureOptions`
- Fix: Use local variable `imageDataToWrite` instead of `CDVCamera` property `self.data` to create the `CGImageSourceRef`. This code was wrong.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
