### PR TITLE
chore(lint): use correct browser config base

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-/**
+/*
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -20,7 +20,7 @@
 const { defineConfig } = require('eslint/config');
 const nodeConfig = require('@cordova/eslint-config/node');
 const nodeTestConfig = require('@cordova/eslint-config/node-tests');
-const browserConfig = require('@cordova/eslint-config/browser-tests');
+const browserConfig = require('@cordova/eslint-config/browser');
 
 module.exports = defineConfig([
     ...browserConfig.map(config => ({


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Use correct base config for browser.

### Description
<!-- Describe your changes in detail -->

There was a small change in https://github.com/apache/cordova-plugin-camera/pull/956 that didn't match the original base configs.

Originally the base config was `@cordova/eslint-config/browser` but accidentally changed to `@cordova/eslint-config/browser-tests`. 

This PR changes it back to `@cordova/eslint-config/browser`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm run lint`

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
