### PR TITLE
fix(android): clean up pending camera temp files on cancel/stop

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -327,6 +327,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 this.cordova.getActivity().finishActivity((sourceType + 1) * 16 + returnType + 1);
             }
         }
+
+        cleanupPendingResultFiles();
     }
 
     public void takePicture(int returnType, int encodingType)
@@ -901,6 +903,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             }// If cancelled
             else if (resultCode == Activity.RESULT_CANCELED) {
+                cleanupPendingResultFiles();
                 this.failPicture("No Image Selected");
             }
 
@@ -930,6 +933,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             // If cancelled
             else if (resultCode == Activity.RESULT_CANCELED) {
+                cleanupPendingResultFiles();
                 this.failPicture("No Image Selected");
             }
 
@@ -949,6 +953,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     }
                 });
             } else if (resultCode == Activity.RESULT_CANCELED) {
+                cleanupPendingResultFiles();
                 this.failPicture("No Image Selected");
             } else {
                 this.failPicture("Selection did not complete!");
@@ -1212,6 +1217,37 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
 
         System.gc();
+    }
+
+    /**
+     * Best-effort cleanup for temporary files when capture/selection is cancelled or stopped.
+     */
+    private void cleanupPendingResultFiles() {
+        deleteIfExists(this.imageUri);
+        deleteIfExists(this.croppedUri);
+
+        if (this.croppedFilePath != null) {
+            new File(this.croppedFilePath).delete();
+            this.croppedFilePath = null;
+        }
+
+        this.imageUri = null;
+        this.croppedUri = null;
+    }
+
+    private void deleteIfExists(Uri uri) {
+        if (uri == null) {
+            return;
+        }
+
+        try {
+            String filePath = FileHelper.stripFileProtocol(uri.toString());
+            if (filePath != null) {
+                new File(filePath).delete();
+            }
+        } catch (Exception ignored) {
+            // Best-effort cleanup only.
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Follow up of PR #873.

@erisu noticed after PR #873 was merged, if there should be any cleanup procedures after `stop` was called. For example when `takePicture` is executed `this.imageUri` is set and gets not cleared. After checking this, it turned out, that this is the case, but this was also true, when an Activity was canceled by the user. This fixes both cases.

### Description
<!-- Describe your changes in detail -->

- delete pending image and cropped temp files when camera flow is stopped
- run cleanup when image selection/capture is canceled
- reset pending URI and file path state after best-effort cleanup

Generated-By: GPT-5.3-Codex


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
