### PR TITLE
fix(ios): reset pending state after `stop` call

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -99,6 +99,8 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 // CDVViewController when a plugin has a pending operation.
 @property (readwrite, assign) BOOL hasPendingOperation;
 
+- (void)resetPendingState;
+
 @end
 
 @implementation CDVCamera
@@ -238,19 +240,29 @@ static NSString* MIME_JPEG    = @"image/jpeg";
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController* presentedViewController = self.viewController.presentedViewController;
         if (presentedViewController == nil) {
+            [self resetPendingState];
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
             return;
         }
 
         [presentedViewController dismissViewControllerAnimated:YES completion:^{
-            self.hasPendingOperation = NO;
-            self.cdvUIImagePickerController = nil;
+            [self resetPendingState];
 
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
         }];
     });
+}
+
+- (void)resetPendingState
+{
+    [self.locationManager stopUpdatingLocation];
+    self.locationManager = nil;
+    self.tempImageDataForLocationManager = nil;
+    self.metadata = nil;
+    self.hasPendingOperation = NO;
+    self.cdvUIImagePickerController = nil;
 }
 
 - (void)sendNoPermissionResult:(NSString*)callbackId


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Follow up of PR #873.

@erisu noticed after PR #873 was merged, if there should be any cleanup procedures after stop was called. For example, on Android, when takePicture is executed this.imageUri is set and gets not cleared. PR #970 fixes this for Android. On iOS no files need to be cleaned up when `stop` is called, for this [camera.cleanup](https://github.com/apache/cordova-plugin-camera#module_camera.cleanup) is intended. But location updates will be cancelled, if they are used, and also the temporary `metadata` variable.

### Description
<!-- Describe your changes in detail -->

- stop and release location updates during stop cleanup
- Defensive clear of temporary `metadata` variable
- reuse the same cleanup path whether a picker is presented or not
- no files need to be cleaned up. These are intended to be removed via `cleanup` call.

Generated-By: GPT-5.3-Codex

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
