### PR TITLE
fix(android): correct EXIF orientation for non-JPEG camera captures

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -526,7 +526,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
         else {
             input = cordova.getActivity().getContentResolver().openInputStream(imageUri);
-            mimeType = FileHelper.getMimeType(imageUri.toString(), cordova);
+            // MediaStore.ACTION_IMAGE_CAPTURE always writes JPEG data into imageUri, regardless of
+            // its file extension (which reflects the requested encodingType, not the actual format).
+            // Relying on FileHelper.getMimeType(imageUri) here would misreport PNG-named captures as
+            // image/png, causing getScaledAndRotatedBitmap() to skip reading the EXIF orientation.
+            mimeType = JPEG_MIME_TYPE;
         }
 
         if (input == null) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- `MediaStore.ACTION_IMAGE_CAPTURE` always writes JPEG data into the capture file, regardless of the requested encodingType/file extension. Deriving the source mimeType from that file's extension (via `FileHelper.getMimeType`) caused PNG-named captures to be misreported as image/png, so `getScaledAndRotatedBitmap()` skipped reading the EXIF orientation and `correctOrientation` had no effect.
- Use the actual JPEG mimeType for the captured source data instead, so orientation correction works regardless of the requested encodingType.
- Fixes #974

Generated-By: Claude Sonnet 5

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
